### PR TITLE
아두이노 확장 블록 state공유 문제 해결.

### DIFF
--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -1937,18 +1937,11 @@ Entry.block = {
             var port = script.getField("PORT", script);
             var nowTime = Entry.ArduinoExt.getSensorTime(Entry.ArduinoExt.sensorTypes.ANALOG);
             var hardwareTime = Entry.hw.portData['TIME'] || 0;
-            if(!Entry.ArduinoExt.BlockState[this.type]) {
-                Entry.ArduinoExt.BlockState[this.type] = {
-                    isStart: false,
-                    stamp: 0
-                }
-            }
-
-            var state = Entry.ArduinoExt.BlockState[this.type];
+            var scope = script.executor.scope;
             var ANALOG = Entry.hw.portData.ANALOG;
-            if(!state.isStart) {
-                state.isStart = true;
-                state.stamp = nowTime;
+            if(!scope.isStart) {
+                scope.isStart = true;
+                scope.stamp = nowTime;
                 Entry.hw.sendQueue['TIME'] = nowTime;
                 Entry.hw.sendQueue['KEY'] = Entry.ArduinoExt.getSensorKey();
                 Entry.hw.sendQueue['GET'] = {
@@ -1957,13 +1950,13 @@ Entry.block = {
                 };
                 throw new Entry.Utils.AsyncError();
                 return;
-            } else if(hardwareTime && (hardwareTime === state.stamp)) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(hardwareTime && (hardwareTime === scope.stamp)) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return (ANALOG) ? ANALOG[port] || 0 : 0;
-            } else if(nowTime - state.stamp > 64) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(nowTime - scope.stamp > 64) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return (ANALOG) ? ANALOG[port] || 0 : 0;
             } else {
                 throw new Entry.Utils.AsyncError();
@@ -2034,19 +2027,12 @@ Entry.block = {
         "func": function (sprite, script) {
             var port1 = script.getField("PORT1", script);
             var port2 = script.getField("PORT2", script);
-            if(!Entry.ArduinoExt.BlockState[this.type]) {
-                Entry.ArduinoExt.BlockState[this.type] = {
-                    isStart: false,
-                    stamp: 0
-                }
-            }
-
-            var state = Entry.ArduinoExt.BlockState[this.type];
+            var scope = script.executor.scope;
             var nowTime = Entry.ArduinoExt.getSensorTime(Entry.ArduinoExt.sensorTypes.ULTRASONIC);
             var hardwareTime = Entry.hw.portData['TIME'] || 0;
-            if(!state.isStart) {
-                state.isStart = true;
-                state.stamp = nowTime;
+            if(!scope.isStart) {
+                scope.isStart = true;
+                scope.stamp = nowTime;
                 Entry.hw.sendQueue['TIME'] = nowTime;
                 Entry.hw.sendQueue['KEY'] = Entry.ArduinoExt.getSensorKey();
                 Entry.hw.sendQueue['GET'] = {
@@ -2055,13 +2041,13 @@ Entry.block = {
                 };
                 throw new Entry.Utils.AsyncError();
                 return;
-            } else if(hardwareTime && (hardwareTime === state.stamp)) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(hardwareTime && (hardwareTime === scope.stamp)) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return Entry.hw.portData.ULTRASONIC || 0;
-            } else if(nowTime - state.stamp > 64) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(nowTime - scope.stamp > 64) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return Entry.hw.portData.ULTRASONIC || 0;
             } else {
                 throw new Entry.Utils.AsyncError();
@@ -2388,18 +2374,11 @@ Entry.block = {
             var port = script.getNumberValue("PORT", script);
             var nowTime = Entry.ArduinoExt.getSensorTime(Entry.ArduinoExt.sensorTypes.DIGITAL);
             var hardwareTime = Entry.hw.portData['TIME'] || 0;
-            if(!Entry.ArduinoExt.BlockState[this.type]) {
-                Entry.ArduinoExt.BlockState[this.type] = {
-                    isStart: false,
-                    stamp: 0
-                }
-            }
-
-            var state = Entry.ArduinoExt.BlockState[this.type];
+            var scope = script.executor.scope;
             var DIGITAL = Entry.hw.portData.DIGITAL;
-            if(!state.isStart) {
-                state.isStart = true;
-                state.stamp = nowTime;
+            if(!scope.isStart) {
+                scope.isStart = true;
+                scope.stamp = nowTime;
                 Entry.hw.sendQueue['TIME'] = nowTime;
                 Entry.hw.sendQueue['KEY'] = Entry.ArduinoExt.getSensorKey();
                 Entry.hw.sendQueue['GET'] = {
@@ -2408,13 +2387,13 @@ Entry.block = {
                 };
                 throw new Entry.Utils.AsyncError();
                 return;
-            } else if(hardwareTime && (hardwareTime === state.stamp)) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(hardwareTime && (hardwareTime === scope.stamp)) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return (DIGITAL) ? DIGITAL[port] || 0 : 0;
-            } else if(nowTime - state.stamp > 64) {
-                delete state.isStart;
-                delete state.stamp;
+            } else if(nowTime - scope.stamp > 64) {
+                delete scope.isStart;
+                delete scope.stamp;
                 return (DIGITAL) ? DIGITAL[port] || 0 : 0;
             } else {
                 throw new Entry.Utils.AsyncError();


### PR DESCRIPTION
ref boolgom/Entry#4218

#### 내용
기존 state를 Entry.ArduinoExt.BlockState에서 관리하여 block scope간 state를 공유하여 실제 값 처리 할때 우선순위에 따라 다르게 처리 되던 문제

#### 처리내용
Entry.ArduinoExt.BlockState에서 executor의 scope로 변경하여 executor별 state값을 가질수 있도록 수정.