### PR TITLE
Update block_entry.js

### DIFF
--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -13299,9 +13299,10 @@ Entry.block = {
                 }
 
                 data_default_address = data_default_address + increase * data_default_length;
-                if (increase != 0) {
-                    data_length = 6 * data_default_length;
-                }
+                data_address = data_default_address;
+                // if (increase != 0) {
+                   // data_length = 6 * data_default_length;
+                // }
 
                 Entry.Robotis_carCont.setRobotisData([[data_instruction, data_address, data_length, data_value, data_default_length]]);
                 // Entry.hw.socket.send(JSON.stringify(Entry.hw.sendQueue));


### PR DESCRIPTION
OpenCM7.0, port 에 연결된 센서값 읽을 때 port 시작 번지 부터 한꺼번에 읽던 것을 해당 주소만 읽도록 수정.