### PR TITLE
issue/3779 (3.1.0 마일스톤)

### DIFF
--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -1896,7 +1896,7 @@ Entry.block = {
         "syntax": {"js": [], "py": ["Albert.set_wheels(%1, %2)"]}
     },
     "arduino_text": {
-        "color": "#00979D",
+        "color": "#FFD974",
         "skeleton": "basic_string_field",
         "statements": [],
         "params": [


### PR DESCRIPTION
boolgom/Entry#3779

아두이노 text블록 색상 변경
#00979D -> #FFD974

![image](https://cloud.githubusercontent.com/assets/5179851/23695198/551a993e-0421-11e7-88d5-187a49eb59f8.png)

![image](https://cloud.githubusercontent.com/assets/5179851/23695205/5af07fd6-0421-11e7-9d3a-a3981e0b059e.png)
