### PR TITLE
이슈 7082 처리

### DIFF
--- a/src/playground.js
+++ b/src/playground.js
@@ -1192,16 +1192,28 @@ Entry.Playground = function() {
                     this.pictureView_.object = this.object;
                     this.injectPicture();
                 } else if(this.object && this.pictureListView_ && !this.pictureListView_.hasChildNodes()) {
-                    this.injectPicture();
+                    var pictures = this.object.pictures;
+                    if(pictures && pictures.length) {
+                        this.injectPicture();
+                    }
                 }
             } else this.painter.hide();
         }
 
-        if (viewType == 'sound' && (!this.soundView_.object ||
-            this.soundView_.object != this.object)) {
-            this.soundView_.object = this.object;
-            this.injectSound();
-        } else if (viewType == 'text' && this.object.objectType == 'textBox' ||
+        if (viewType == 'sound') {
+            if (!this.soundView_.object ||
+                this.soundView_.object != this.object) {
+                this.soundView_.object = this.object;
+                this.injectSound();
+            } else if(this.object && this.soundListView_ && !this.soundListView_.hasChildNodes()) {
+                var sounds = this.object.sounds;
+                if(sounds && sounds.length) {
+                    this.injectSound();
+                }
+            }
+        }
+
+        if (viewType == 'text' && this.object.objectType == 'textBox' ||
             (this.textView_.object != this.object)) {
             this.textView_.object = this.object;
             this.injectText();

--- a/src/playground.js
+++ b/src/playground.js
@@ -1191,6 +1191,8 @@ Entry.Playground = function() {
                     this.pictureView_.object != this.object) {
                     this.pictureView_.object = this.object;
                     this.injectPicture();
+                } else if(this.object && this.pictureListView_ && !this.pictureListView_.hasChildNodes()) {
+                    this.injectPicture();
                 }
             } else this.painter.hide();
         }


### PR DESCRIPTION
boolgom/Entry#7082 처리

#### 원인
장면에 오브젝트가 비어 있는 경우 currentObject의 변화가 발생하지 않음.
이 상태에서 다시 오브젝트가 존재하는 장면으로 이동할 경우 currentObject와 현재 장면의 첫번째 
오브젝트를 비교 하게되는데 해당 비교에서 오브젝트가 동일 할 경우 
모양 및 소리 탭의 리스트를 갱신 하지 않는 문제.

#### 해결
현재 선택된 오브젝트와 장면의 첫번째 오브젝트가 동일해도 실제 리스트에 해당 아이템이 없는 경우에는 
강제로 아이템을 그리도록 수정함.