### PR TITLE
issue Entry/#7101 소리재생불가 오류관련

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -166,6 +166,7 @@ Entry.enableArduino = function() {
  * @param {sound object} sound
  */
 Entry.initSound = function(sound) {
+    if (!sound || !sound.duration || sound.duration == 0) return;
     if (sound.fileurl) {
         sound.path = sound.fileurl;
     } else {


### PR DESCRIPTION
- https://github.com/boolgom/Entry/issues/7101
- 사운드 파일에서 오류 발생시(Uncaught DOMException: Unable to decode audio data) 해당 사운드외 다른 사운드까지 재생이 안되는 오류를 방지하기 위한 방어코드.