### PR TITLE
[3.6.0] set copyable false for fieldLabel block

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -296,6 +296,7 @@ Entry.Func.setupMenuCode = function() {
     var CATEGORY = 'func';
     this._fieldLabel = menuCode.createThread([{
         type: "function_field_label",
+        copyable: false,
         category: CATEGORY,
         x: -9999
     }]).getFirstBlock();


### PR DESCRIPTION
ref https://github.com/boolgom/Entry/issues/7112

** [WS] 함수 만들기 > 이름 블록에 문자/숫자값 블록과 판단값 블록을 조립 > 만든 블록 복사, 붙여넣기 > 함수에 블록 조립 > 넘버링 오류 