### PR TITLE
ios 좌표 관련 버그 수정

### DIFF
--- a/src/stage.js
+++ b/src/stage.js
@@ -93,8 +93,14 @@ Entry.Stage.prototype.initStage = function(canvas) {
         Entry.stage.updateBoundRect();
     });
 
+    var razyScroll = _.debounce(function () {
+        Entry.windowResized.notify();
+    }, 200);
+    
     $(window).scroll(function() {
-        Entry.stage.updateBoundRect();
+        window.requestAnimationFrame(function () {
+            razyScroll();
+        });
     });
 
     var moveFunc = function(e){

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -273,6 +273,39 @@ Entry.Utils.hslToHex = function(color) {
     return '#' + hex.join('');
 };
 
+Entry.Utils.setSVGDom = function (SVGDom) {
+    Entry.Utils.SVGDom = SVGDom;
+}
+
+Entry.Utils.bindIOSDeviceWatch = function() {
+    var Agent = Entry.Utils.mobileAgentParser();
+    if(Agent.apple.device) {
+        console.log('APPLE! MOBILE DEVICE');
+        var lastHeight = window.innerHeight || document.documentElement.clientHeight;
+        var lastSVGDomHeight = 0;
+        if(Entry.Utils.SVGDom) {
+            lastSVGDomHeight = Entry.Utils.SVGDom.height();
+        }
+
+        setInterval(function () {
+            var nowHeight = window.innerHeight || document.documentElement.clientHeight;
+            var SVGDomCheck = false;
+            if(Entry.Utils.SVGDom) {
+                var nowSVGDomHeight = Entry.Utils.SVGDom.height();
+                SVGDomCheck = lastSVGDomHeight != nowSVGDomHeight;
+                lastSVGDomHeight = nowSVGDomHeight;
+            }
+            if(lastHeight != nowHeight || SVGDomCheck) {
+                Entry.windowResized.notify();
+            };
+            lastHeight = nowHeight;
+        }, 1000);
+
+        $(window).on('orientationchange', (function(e) {
+            Entry.windowResized.notify();
+        }));
+    }
+}
 
 Entry.Utils.bindGlobalEvent = function(options) {
     var doc = $(document);
@@ -295,6 +328,7 @@ Entry.Utils.bindGlobalEvent = function(options) {
         $(window).on('resize', (function(e) {
             Entry.windowResized.notify(e);
         }));
+        Entry.Utils.bindIOSDeviceWatch();
     }
 
     if (options.indexOf('mousedown') > -1) {
@@ -1384,6 +1418,108 @@ Entry.isMobile = function() {
         Entry.device = 'desktop';
         return false;
     }
+}
+
+Entry.Utils.mobileAgentParser = function (userAgent) {
+    var apple_phone         = /iPhone/i,
+        apple_ipod          = /iPod/i,
+        apple_tablet        = /iPad/i,
+        android_phone       = /(?=.*\bAndroid\b)(?=.*\bMobile\b)/i, // Match 'Android' AND 'Mobile'
+        android_tablet      = /Android/i,
+        amazon_phone        = /(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,
+        amazon_tablet       = /(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,
+        windows_phone       = /Windows Phone/i,
+        windows_tablet      = /(?=.*\bWindows\b)(?=.*\bARM\b)/i, // Match 'Windows' AND 'ARM'
+        other_blackberry    = /BlackBerry/i,
+        other_blackberry_10 = /BB10/i,
+        other_opera         = /Opera Mini/i,
+        other_chrome        = /(CriOS|Chrome)(?=.*\bMobile\b)/i,
+        other_firefox       = /(?=.*\bFirefox\b)(?=.*\bMobile\b)/i, // Match 'Firefox' AND 'Mobile'
+        seven_inch = new RegExp(
+            '(?:' +         // Non-capturing group
+
+            'Nexus 7' +     // Nexus 7
+
+            '|' +           // OR
+
+            'BNTV250' +     // B&N Nook Tablet 7 inch
+
+            '|' +           // OR
+
+            'Kindle Fire' + // Kindle Fire
+
+            '|' +           // OR
+
+            'Silk' +        // Kindle Fire, Silk Accelerated
+
+            '|' +           // OR
+
+            'GT-P1000' +    // Galaxy Tab 7 inch
+
+            ')',            // End non-capturing group
+
+            'i');           // Case-insensitive matching
+
+    var match = function(regex, userAgent) {
+        return regex.test(userAgent);
+    };
+
+    var ua = userAgent || navigator.userAgent;
+
+    // Facebook mobile app's integrated browser adds a bunch of strings that
+    // match everything. Strip it out if it exists.
+    var tmp = ua.split('[FBAN');
+    if (typeof tmp[1] !== 'undefined') {
+        ua = tmp[0];
+    }
+
+    // Twitter mobile app's integrated browser on iPad adds a "Twitter for
+    // iPhone" string. Same probable happens on other tablet platforms.
+    // This will confuse detection so strip it out if it exists.
+    tmp = ua.split('Twitter');
+    if (typeof tmp[1] !== 'undefined') {
+        ua = tmp[0];
+    }
+
+    this.apple = {
+        phone:  match(apple_phone, ua),
+        ipod:   match(apple_ipod, ua),
+        tablet: !match(apple_phone, ua) && match(apple_tablet, ua),
+        device: match(apple_phone, ua) || match(apple_ipod, ua) || match(apple_tablet, ua)
+    };
+    this.amazon = {
+        phone:  match(amazon_phone, ua),
+        tablet: !match(amazon_phone, ua) && match(amazon_tablet, ua),
+        device: match(amazon_phone, ua) || match(amazon_tablet, ua)
+    };
+    this.android = {
+        phone:  match(amazon_phone, ua) || match(android_phone, ua),
+        tablet: !match(amazon_phone, ua) && !match(android_phone, ua) && (match(amazon_tablet, ua) || match(android_tablet, ua)),
+        device: match(amazon_phone, ua) || match(amazon_tablet, ua) || match(android_phone, ua) || match(android_tablet, ua)
+    };
+    this.windows = {
+        phone:  match(windows_phone, ua),
+        tablet: match(windows_tablet, ua),
+        device: match(windows_phone, ua) || match(windows_tablet, ua)
+    };
+    this.other = {
+        blackberry:   match(other_blackberry, ua),
+        blackberry10: match(other_blackberry_10, ua),
+        opera:        match(other_opera, ua),
+        firefox:      match(other_firefox, ua),
+        chrome:       match(other_chrome, ua),
+        device:       match(other_blackberry, ua) || match(other_blackberry_10, ua) || match(other_opera, ua) || match(other_firefox, ua) || match(other_chrome, ua)
+    };
+    this.seven_inch = match(seven_inch, ua);
+    this.any = this.apple.device || this.android.device || this.windows.device || this.other.device || this.seven_inch;
+
+    // excludes 'other' devices and ipods, targeting touchscreen phones
+    this.phone = this.apple.phone || this.android.phone || this.windows.phone;
+
+    // excludes 7 inch devices, classifying as phone or tablet is left to the user
+    this.tablet = this.apple.tablet || this.android.tablet || this.windows.tablet;
+
+    return this;
 }
 
 Entry.Utils.convertMouseEvent = function(e) {

--- a/src/workspace/board.js
+++ b/src/workspace/board.js
@@ -37,6 +37,7 @@ Entry.Board = function(option) {
     this._addControl();
     this._bindEvent();
     Entry.addEventListener('fontLoaded', this.reDraw.bind(this));
+    Entry.Utils.setSVGDom(this.svgDom);
 };
 
 Entry.Board.OPTION_PASTE = 0;


### PR DESCRIPTION
IOS 디바이스
(애플 모바일 디바이스)
에서 scroll, resize, orientationchange 이벤트 발생시
실제 그려질 UI와 계산된 UI가 달라 일부 요소들의 좌표가 잘못 계산되어짐.
IOS환경이면 1초 주기로 돌면서 변경이 Resize요소가 발생하면 Resize Event를 Notify하도록 수정

그리고 기존에 scroll발생시 Resize Notify가 너무 많이 발생되던 부분을
debounce처리로 빈도수를 줄임.
