### PR TITLE
Issue/3558

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -583,6 +583,10 @@ Entry.EntityObject.prototype.syncFont = function() {
                 this.setHeight(this.fontSize * 1.1);
                 break;
             }
+            case "Nanum Myeongjo": {
+                this.setHeight(this.fontSize * 1.1);
+                break;
+            }
             default: {
                 this.setHeight(this.fontSize);
                 break;

--- a/src/entity.js
+++ b/src/entity.js
@@ -1184,6 +1184,7 @@ Entry.EntityObject.prototype.alignTextBox = function () {
                 textObject.x = this.getWidth() / 2;
                 break;
         }
+        textObject.maxHeight = this.getHeight();
     } else {
         textObject.x = 0;
         textObject.y = 0;


### PR DESCRIPTION
- https://github.com/boolgom/Entry/issues/3558 글상자 이슈
- 명조체 높이 조절
- 여러줄 줄일때 숨김 처리 (textObject.maxHeight 누락부분 추가)
