### PR TITLE
add block_entry_mini.js

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,5 +8,6 @@ cp -r dist build/
 cp -r extern build/
 cp -r images build/
 rsync -R src/workspace/block_entry.js build
+rsync -R src/workspace/block_entry_mini.js build
 ls -al
 ls -al build


### PR DESCRIPTION
이번 교과형 부터 travis 빌드시 포함되어야 될 block_entry_mini 파일이

포함되지 않아 블록이 정상적으로 노출되지 않는 상태에 있었음.

해당 파일 빌드에 포함하여 이상없도록 수정.