### PR TITLE
[3.9.0] timerView bug fix

### DIFF
--- a/src/workspace/block_view.js
+++ b/src/workspace/block_view.js
@@ -90,7 +90,7 @@ Entry.BlockView = function(block, board, mode) {
     this.dragMode = Entry.DRAG_MODE_NONE;
     Entry.Utils.disableContextmenu(this.svgGroup.node);
     var events = block.events.viewAdd;
-    if (Entry.type == 'workspace' && events && !this.isInBlockMenu) {
+    if (Entry.type == 'workspace' && events && this._board instanceof Entry.Board) {
         events.forEach(function(fn) {
             if (Entry.Utils.isFunction(fn)) fn(block);
         });


### PR DESCRIPTION
https://github.com/boolgom/Entry/issues/7749

** [WS] 도움말로 초시계 관련 블럭들을 선택 한 후 다른 블록 탭으로 이동 시 초시계 블럭 생성 없이 초시계 기능이 추가 되는 현상

** 블록 도움말의 경우 초시게 view가 생성되지 않도록 함
