### PR TITLE
이슈 7818 처리

### DIFF
--- a/src/workspace/workspace.js
+++ b/src/workspace/workspace.js
@@ -108,6 +108,10 @@ Entry.Workspace.MODE_OVERLAYBOARD = 2;
     p.getMode = function() {return this.mode;};
 
     p.setMode = function(mode, message, isForce) {
+        if (!Entry.options.textCodingEnable && Entry.Workspace.MODE_VIMBOARD === mode.boardType) {
+            return;
+        }
+
         Entry.disposeEvent.notify();
 
         var playground = Entry.playground;
@@ -379,6 +383,9 @@ Entry.Workspace.MODE_OVERLAYBOARD = 2;
                     }
                     break;
                 case 219: //setMode(block) for textcoding
+                    if (!Entry.options.textCodingEnable) {
+                        return;
+                    }
                     var oldMode = Entry.getMainWS().oldMode;
                     if(oldMode == Entry.Workspace.MODE_OVERLAYBOARD)
                         return;
@@ -396,6 +403,9 @@ Entry.Workspace.MODE_OVERLAYBOARD = 2;
                     e.preventDefault();
                     break;
                 case 221: //setMode(python) for textcoding
+                    if (!Entry.options.textCodingEnable) {
+                        return;
+                    }
                     var message;
                     message = Entry.TextCodingUtil.canConvertTextModeForOverlayMode(Entry.Workspace.MODE_VIMBOARD);
                     if(message) {


### PR DESCRIPTION
boolgom/Entry#7818

Entry.init 할 당시에 options 값의 textCodingEnable 값이 false인경우
단축키인 `Ctrl + [`과 `Ctrl + ]`의 동작을 막고
기본적으로 setMode로 모드 전환시 VimBorad로의 전환을 막음.