### PR TITLE
Issue/556

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -212,8 +212,7 @@ Entry.Container.prototype.setObjects = function(objectModels) {
         this.objects_.push(object);
     }
     this.updateObjectsOrder();
-    var isStageSorted = this.updateListView();
-    !isStageSorted && Entry.stage.sortZorder();
+    this.updateListView();
     Entry.variableContainer.updateViews();
     var type = Entry.type;
     if (type == 'workspace' || type == 'phone') {
@@ -558,19 +557,6 @@ Entry.Container.prototype.moveElement = function(start, end, isCallFromState) {
     return new Entry.State(Entry.container,
                            Entry.container.moveElement,
                            endIndex, startIndex, true);
-};
-
-/**
- * Move object in objects_
- * this method is for movement by block
- * @param {!number} currentindex
- * @param {!number} targetindex
- */
-Entry.Container.prototype.moveElementByBlock = function(currentIndex, targetIndex) {
-    var object = this.getCurrentObjects().splice(currentIndex, 1)[0];
-    this.getCurrentObjects().splice(targetIndex, 0, object);
-    Entry.stage.sortZorder();
-    this.updateListView();
 };
 
 /**

--- a/src/entity.js
+++ b/src/entity.js
@@ -17,6 +17,7 @@ Entry.EntityObject = function(object) {
     this.collision = Entry.Utils.COLLISION.NONE;
     this.id = Entry.generateHash();
     this.removed = false;
+    this.stamps = [];
 
     if (this.type == 'sprite') {
         this.object = new createjs.Bitmap();
@@ -1186,6 +1187,24 @@ Entry.EntityObject.prototype.syncDialogVisible = function() {
     if (this.dialog) this.dialog.object.visible = this.visible;
 };
 
+Entry.EntityObject.prototype.addStamp = function() {
+    var stampEntity = new Entry.StampEntity(this.parent, this);
+    var stage = Entry.stage;
+    stage.loadEntity(stampEntity);
+    this.stamps.push(stampEntity);
+    
+    Entry.requestUpdate = true;
+};
+
+Entry.EntityObject.prototype.removeStamps = function() {
+    this.stamps.map(function(s) {
+        s.destroy();
+    });
+
+    this.stamps = [];
+    Entry.requestUpdate = true;
+};
+
 Entry.EntityObject.prototype.destroy = function(isClone) {
     if (this.removed) return;
 
@@ -1198,6 +1217,8 @@ Entry.EntityObject.prototype.destroy = function(isClone) {
         delete object.image;
         delete object.entity;
     }
+    if (this.stamps)
+        this.removeStamps();
 
     this.dialog && this.dialog.remove();
     this.brush && this.removeBrush();

--- a/src/entity.js
+++ b/src/entity.js
@@ -1190,7 +1190,10 @@ Entry.EntityObject.prototype.syncDialogVisible = function() {
 Entry.EntityObject.prototype.addStamp = function() {
     var stampEntity = new Entry.StampEntity(this.parent, this);
     var stage = Entry.stage;
-    stage.loadEntity(stampEntity);
+    var selectedObjectContainer = Entry.stage.selectedObjectContainer;
+    var index = selectedObjectContainer.getChildIndex(this.object);
+    if (this.shape) index--;
+    stage.loadEntity(stampEntity, index);
     this.stamps.push(stampEntity);
     
     Entry.requestUpdate = true;

--- a/src/object.js
+++ b/src/object.js
@@ -549,8 +549,6 @@ Entry.EntryObject = function(model) {
             clonedEntity.applyFilter();
         }
 
-        if (entity.brush) Entry.setCloneBrush(clonedEntity, entity.brush);
-
         Entry.engine.raiseEventOnEntity(
             clonedEntity,
             [clonedEntity, 'when_clone_start']
@@ -568,6 +566,8 @@ Entry.EntryObject = function(model) {
         if (entity.shape)
             targetIndex--;
         Entry.stage.loadEntity(clonedEntity, targetIndex);
+        
+        if (entity.brush) Entry.setCloneBrush(clonedEntity, entity.brush);
     };
 
     /**

--- a/src/object.js
+++ b/src/object.js
@@ -564,7 +564,10 @@ Entry.EntryObject = function(model) {
         );
 
         this.clonedEntities.push(clonedEntity);
-        Entry.stage.loadEntity(clonedEntity);
+        var targetIndex = Entry.stage.selectedObjectContainer.getChildIndex(entity.object);
+        if (entity.shape)
+            targetIndex--;
+        Entry.stage.loadEntity(clonedEntity, targetIndex);
     };
 
     /**
@@ -771,9 +774,12 @@ Entry.EntryObject = function(model) {
     p.addStampEntity = function(entity) {
         var stampEntity = new Entry.StampEntity(this, entity);
         var stage = Entry.stage;
-        stage.loadEntity(stampEntity);
+        var selectedObjectContainer = stage.selectedObjectContainer;
+        var targetIndex = selectedObjectContainer.getChildIndex(entity.object);
+        if (entity.shape)
+            targetIndex--;
+        stage.loadEntity(stampEntity, targetIndex);
         this.clonedEntities.push(stampEntity);
-        Entry.stage.sortZorder();
     };
 
     /**

--- a/src/object.js
+++ b/src/object.js
@@ -764,46 +764,21 @@ Entry.EntryObject = function(model) {
     };
 
     /**
-     * Add stamp entity for brush_stamp block
-     * If parameter given, this clone the parameter entity itself.
-     * Otherwise, this clone this object's entity.
-     * @param {?Entry.EntryObject} object
-     * @param {?Entry.EntityObject} entity
-     * @param {?xml block} script
-     */
-    p.addStampEntity = function(entity) {
-        var stampEntity = new Entry.StampEntity(this, entity);
-        var stage = Entry.stage;
-        var selectedObjectContainer = stage.selectedObjectContainer;
-        var targetIndex = selectedObjectContainer.getChildIndex(entity.object);
-        if (entity.shape)
-            targetIndex--;
-        stage.loadEntity(stampEntity, targetIndex);
-        this.clonedEntities.push(stampEntity);
-    };
-
-    /**
      *  get only clonedEntities among clonedEntities except for stamp entity
      *  @return {Array<clone Entity> } entities
      */
     p.getClonedEntities = function() {
-        return this.clonedEntities.filter(function (e) { return !e.isStamp; });
-    };
-
-    /**
-     *  get only stamp entities among clonedEntities
-     *  @return {Array<stampEntity> } entities
-     */
-    p.getStampEntities = function() {
-        return this.clonedEntities.filter(function (e) { return e.isStamp; });
+        return this.clonedEntities.concat();
     };
 
     p.clearExecutor = function() {
         this.script.clearExecutors();
 
         var clonedEntities = this.clonedEntities;
-        for (var j = clonedEntities.length-1; j>=0; j--)
+        for (var j = clonedEntities.length-1; j>=0; j--) {
             clonedEntities[j].removeClone(true);
+        }
+        this.entity.removeStamps();
     };
 
     p._rightClick = function(e) {

--- a/src/playground.js
+++ b/src/playground.js
@@ -1072,7 +1072,6 @@ Entry.Playground = function() {
         this.object.pictures.splice(
             end, 0, this.object.pictures.splice(start, 1)[0]);
         this.injectPicture();
-        Entry.stage.sortZorder();
     };
 
     /**
@@ -1159,7 +1158,6 @@ Entry.Playground = function() {
         this.object.sounds.splice(
             end, 0, this.object.sounds.splice(start, 1)[0]);
         this.updateListViewOrder('sound');
-        Entry.stage.sortZorder();
     };
 
     /**

--- a/src/scene.js
+++ b/src/scene.js
@@ -352,8 +352,6 @@ Entry.Scene.prototype.selectScene = function(scene) {
         Entry.variableContainer.updateList();
     }
 
-    !container.listView_ && stage.sortZorder();
-
     container.updateListView();
     this.updateView();
     Entry.requestUpdate = true;

--- a/src/stage.js
+++ b/src/stage.js
@@ -319,6 +319,13 @@ Entry.Stage.prototype.sortZorder = function() {
 };
 
 /**
+ * sort Z index of objects while running
+ */
+Entry.Stage.prototype.sortZorderRun = function() {
+    Entry.requestUpdate = true;
+};
+
+/**
  * Initialize coordinate on canvas. It is toggle by Engine.
  */
 Entry.Stage.prototype.initCoordinator = function() {

--- a/src/stage.js
+++ b/src/stage.js
@@ -278,7 +278,13 @@ Entry.Stage.prototype.setEntityIndex = function(entity, index) {
         selectedObjectContainer.setChildIndex(entity.object, index);
         if (entity.shape)
             selectedObjectContainer.setChildIndex(entity.shape, index);
+        entity.stamps.concat().reverse().map(function(s) {
+            selectedObjectContainer.setChildIndex(s.object, index);
+        });
     } else {
+        entity.stamps.map(function(s) {
+            selectedObjectContainer.setChildIndex(s.object, index);
+        });
         if (entity.shape)
             selectedObjectContainer.setChildIndex(entity.shape, index);
         selectedObjectContainer.setChildIndex(entity.object, index);

--- a/src/stage.js
+++ b/src/stage.js
@@ -211,11 +211,14 @@ Entry.Stage.prototype.loadObject = function(object) {
  * This is use for cloned entity
  * @param {Entry.EntityObject} entity
  */
-Entry.Stage.prototype.loadEntity = function(entity) {
+Entry.Stage.prototype.loadEntity = function(entity, index) {
     var scene = entity.parent.scene;
     var objContainer = Entry.stage.getObjectContainerByScene(scene);
-    objContainer.addChild(entity.object);
-    this.sortZorder();
+    if (index > -1)
+        objContainer.addChildAt(entity.object, index);
+    else
+        objContainer.addChild(entity.object);
+    Entry.requestUpdate = true;
 };
 
 /**
@@ -263,6 +266,24 @@ Entry.Stage.prototype.loadDialog = function(dialog) {
  */
 Entry.Stage.prototype.unloadDialog = function(dialog) {
     this.dialogContainer.removeChild(dialog.object);
+};
+
+Entry.Stage.prototype.setEntityIndex = function(entity, index) {
+    var selectedObjectContainer = Entry.stage.selectedObjectContainer;
+    var currentIndex = selectedObjectContainer.getChildIndex(entity.object);
+    
+    if (currentIndex === index) {
+        return;
+    } else if (currentIndex > index) {
+        selectedObjectContainer.setChildIndex(entity.object, index);
+        if (entity.shape)
+            selectedObjectContainer.setChildIndex(entity.shape, index);
+    } else {
+        if (entity.shape)
+            selectedObjectContainer.setChildIndex(entity.shape, index);
+        selectedObjectContainer.setChildIndex(entity.object, index);
+    }
+    Entry.requestUpdate = true;
 };
 
 /**

--- a/src/stamp_entity.js
+++ b/src/stamp_entity.js
@@ -28,7 +28,7 @@ Entry.StampEntity = function(object, entity) {
         }
     } else if (this.type == 'textBox') {}
 
-    this.object.entity = this;
+    this.object.entity = entity;
 };
 
 

--- a/src/stamp_entity.js
+++ b/src/stamp_entity.js
@@ -35,7 +35,6 @@ Entry.StampEntity = function(object, entity) {
 (function(p, origin) {
     [
         'applyFilter',
-        'removeClone',
         'getWidth',
         'getHeight',
         'getInitialEffectValue',

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1008,11 +1008,12 @@ Entry.setBasicBrush = function (sprite) {
     brush.opacity = 100;
     brush.setStrokeStyle(1);
     brush.beginStroke("rgba(255,0,0,1)");
+    brush.entity = sprite;
 
     var shape = new createjs.Shape(brush);
+    shape.entity = sprite;
     var selectedObjectContainer = Entry.stage.selectedObjectContainer;
-    selectedObjectContainer.addChild(shape);
-    selectedObjectContainer.setChildIndex(
+    selectedObjectContainer.addChildAt(
         shape,
         selectedObjectContainer.getChildIndex(sprite.object)
     );
@@ -1036,7 +1037,12 @@ Entry.setCloneBrush = function (sprite, parentBrush) {
     brush.beginStroke("rgba("+brush.rgb.r+","+brush.rgb.g+","+brush.rgb.b+","+(brush.opacity/100)+")");
 
     var shape = new createjs.Shape(brush);
-    Entry.stage.selectedObjectContainer.addChild(shape);
+    shape.entity = sprite;
+    var selectedObjectContainer = Entry.stage.selectedObjectContainer;
+    selectedObjectContainer.addChildAt(
+        shape,
+        selectedObjectContainer.getChildIndex(sprite.object)
+    );
 
     brush.stop = parentBrush.stop;
 

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1010,7 +1010,12 @@ Entry.setBasicBrush = function (sprite) {
     brush.beginStroke("rgba(255,0,0,1)");
 
     var shape = new createjs.Shape(brush);
-    Entry.stage.selectedObjectContainer.addChild(shape);
+    var selectedObjectContainer = Entry.stage.selectedObjectContainer;
+    selectedObjectContainer.addChild(shape);
+    selectedObjectContainer.setChildIndex(
+        shape,
+        selectedObjectContainer.getChildIndex(sprite.object)
+    );
 
     if (sprite.brush)
         sprite.brush = null;

--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -30294,28 +30294,32 @@ Entry.block = {
     "class": "z-index",
     "isNotFor": [],
     "func": function (sprite, script) {
-        var targetIndex;
         var location = script.getField("LOCATION", script);
         var selectedObjectContainer = Entry.stage.selectedObjectContainer;
         var currentIndex = selectedObjectContainer.getChildIndex(sprite.object);
         var max = selectedObjectContainer.children.length - 1;
+        var targetIndex = currentIndex;
 
         switch (location) {
             case 'FRONT':
                 targetIndex = max;
                 break;
             case 'FORWARD':
-                targetIndex = Math.min(max, currentIndex + 1);
-                var frontEntity = selectedObjectContainer.getChildAt(targetIndex)
-                if (frontEntity && frontEntity !== sprite.object && frontEntity instanceof createjs.Shape)
-                    targetIndex++;
+                if (currentIndex === max)
+                    break;
+                    
+                var frontEntity = selectedObjectContainer.getChildAt(currentIndex + 1).entity;
+                targetIndex += (frontEntity.shape ? 2 : 1) + frontEntity.stamps.length;
                 break;
             case 'BACKWARD':
-                targetIndex = sprite.shape ? currentIndex - 2 : currentIndex - 1;
-                targetIndex = Math.max(0, targetIndex);
-                var backEntity = selectedObjectContainer.getChildAt(targetIndex - 1)
-                if (backEntity && backEntity instanceof createjs.Shape)
-                    targetIndex--;
+                targetIndex -= (sprite.shape ? 2 : 1) + sprite.stamps.length;
+                var backEntity = selectedObjectContainer.getChildAt(targetIndex);
+                if (!backEntity) {
+                    targetIndex = 0;
+                    break;
+                }
+                backEntity = backEntity.entity;
+                targetIndex -= (backEntity.shape ? 1 : 0) + backEntity.stamps.length;
                 break;
             case 'BACK':
                 targetIndex = 0;

--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -10247,11 +10247,7 @@ Entry.block = {
     "func": function (sprite, script) {
         sprite.eraseBrush && sprite.eraseBrush();
 
-        var stampEntities = sprite.parent.getStampEntities();
-        stampEntities.map(function (entity) {
-            entity.removeClone();
-        });
-        stampEntities = null;
+        sprite.removeStamps();
 
         return script.callReturn();
     },
@@ -10276,7 +10272,7 @@ Entry.block = {
     "class": "stamp",
     "isNotFor": [ "textBox" ],
     "func": function (sprite, script) {
-        sprite.parent.addStampEntity(sprite);
+        sprite.addStamp();
 
         return script.callReturn();
     },

--- a/src/workspace/block_entry.js
+++ b/src/workspace/block_entry.js
@@ -9871,7 +9871,6 @@ Entry.block = {
         else
             Entry.setBasicBrush(sprite);
 
-        Entry.stage.sortZorder();
         sprite.brush.moveTo(sprite.getX(), sprite.getY()*-1);
 
         return script.callReturn();
@@ -29844,7 +29843,6 @@ Entry.block = {
         var currentIndex = Entry.container.getCurrentObjects().indexOf(sprite.parent);
 
         if (currentIndex > -1) {
-            Entry.container.moveElementByBlock(currentIndex, targetIndex);
             return script.callReturn();
         } else
             throw new Error('object is not available');
@@ -30302,30 +30300,34 @@ Entry.block = {
     "func": function (sprite, script) {
         var targetIndex;
         var location = script.getField("LOCATION", script);
-        var objects = Entry.container.getCurrentObjects();
-        var currentIndex = objects.indexOf(sprite.parent);
-        var max = objects.length-1
-
-        if (currentIndex < 0)
-            throw new Error('object is not available for current scene');
+        var selectedObjectContainer = Entry.stage.selectedObjectContainer;
+        var currentIndex = selectedObjectContainer.getChildIndex(sprite.object);
+        var max = selectedObjectContainer.children.length - 1;
 
         switch (location) {
             case 'FRONT':
-                targetIndex = 0;
+                targetIndex = max;
                 break;
             case 'FORWARD':
-                targetIndex = Math.max(0, currentIndex-1);
+                targetIndex = Math.min(max, currentIndex + 1);
+                var frontEntity = selectedObjectContainer.getChildAt(targetIndex)
+                if (frontEntity && frontEntity !== sprite.object && frontEntity instanceof createjs.Shape)
+                    targetIndex++;
                 break;
             case 'BACKWARD':
-                targetIndex = Math.min(max, currentIndex+1);
+                targetIndex = sprite.shape ? currentIndex - 2 : currentIndex - 1;
+                targetIndex = Math.max(0, targetIndex);
+                var backEntity = selectedObjectContainer.getChildAt(targetIndex - 1)
+                if (backEntity && backEntity instanceof createjs.Shape)
+                    targetIndex--;
                 break;
             case 'BACK':
-                targetIndex = max;
+                targetIndex = 0;
                 break;
 
         }
+        Entry.stage.setEntityIndex(sprite, targetIndex)
 
-        Entry.container.moveElementByBlock(currentIndex, targetIndex);
         return script.callReturn();
     },
     "syntax": {"js": [], "py": [


### PR DESCRIPTION
boolgom/Entry#556

실행화면에서 z-index 관리를 오브젝트 단위로 하지 않고 (복제본-붓-도장) 을 한 묶음으로 하여 관리됩니다.

sortZorder 는 일종의 silver bullet 처럼 사용되었으나 이제 실행중에는 sortZorder 를 호출하지 않습니다.(sortZorder 를 실행하면 z-index 가 망가집니다.)

또한 오브젝트 단위로 관리되던 도장이 각 복제본에 종속되어 붓 지우기 블록의 동작이 변경되게 되었습니다.