### PR TITLE
text object underline initialize

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -92,15 +92,13 @@ Entry.EntityObject.prototype.injectModel = function(pictureModel, entityModel) {
         this.setFont(entityModel.font);
         this.setBGColour(entityModel.bgColor);
         this.setColour(entityModel.colour);
-        this.setUnderLine(entityModel.underLine);
+        this.setUnderLine(entityModel.underline);
         this.setStrike(entityModel.strike);
         this.setText(entityModel.text);
     }
 
     //entity
-    if (entityModel) {
-        this.syncModel_(entityModel);
-    } else {}
+    if (entityModel) { this.syncModel_(entityModel); }
 };
 
 /**


### PR DESCRIPTION
https://github.com/boolgom/Entry/issues/8123

** [WS] 글상자 오브젝트 생성 시 밑줄 효과가 적용 되지 않음 #8123