### PR TITLE
Issue/8699

### DIFF
--- a/src/css/components/object.less
+++ b/src/css/components/object.less
@@ -404,7 +404,7 @@ input.entryObjectNameWorkspace:-moz-read-only {
 }
 
 .entryObjectCoordinateInputWorkspace {
-    width: 40px;
+    width: 45px;
     height: 20px;
     background-color: #e5e5e5;
     border: none;


### PR DESCRIPTION
https://oss.navercorp.com/entry/Entry/issues/8699

오브젝트의 Y좌표가 마이너스 3자리수 일 때, 소수점 부분이 잘리는 부분 노출