### PR TITLE
issue 8890 처리

### DIFF
--- a/src/command/commands/block.js
+++ b/src/command/commands/block.js
@@ -76,16 +76,21 @@
     c[COMMAND_TYPES.destroyThread] = {
         do: function(thread) {
             // thread can be index
-            if (!(thread instanceof Entry.Thread))
+            if (!(thread instanceof Entry.Thread)) {
                 thread = this.editor.board.code.getThread(thread);
-            var block = thread.getFirstBlock();
-            block.destroy(true, true);
+            }
+            if(thread) {
+                var block = thread.getFirstBlock();
+                block.destroy(true, true);
+            }
         },
         state: function(thread) {
-            if (!(thread instanceof Entry.Thread))
+            if (!(thread instanceof Entry.Thread)) {
                 thread = this.editor.board.code.getThread(thread);
-            var index = this.editor.board.code.getThreadIndex(thread);
-            return [thread.toJSON(), index];
+            }
+            const index = this.editor.board.code.getThreadIndex(thread);
+            const json = thread ? thread.toJSON() : {};
+            return [json, index];
         },
         log: function(threadIndex) {
             if (threadIndex instanceof Entry.Thread)


### PR DESCRIPTION
https://oss.navercorp.com/entry/Entry/issues/8890

블록 thread에서 바로 쓰레기통을 삭제하는 액션할때
destory가 2번 호출되어 오류가 발생하는 문제 수정.