### PR TITLE
[#9132] 변수명을 변경했을 때 조립된 변수값블록의 변수명이 변경되지 않는 오류

### DIFF
--- a/src/playground/block_view.js
+++ b/src/playground/block_view.js
@@ -1171,7 +1171,11 @@ Entry.BlockView.RENDER_MODE_TEXT = 2;
         this._updateContents(true);
 
         //해당 블럭이 가진 파라미터가 다른 블럭인 경우 재귀로 동작. indicator(undefined), string 은 제외
-        (this.block.data.params || []).forEach((param) => param && param.data && param.data.view && param.data.view.reDraw());
+        (this.block.data.params || []).forEach((param) => {
+            if(_.has(param, 'data.view')){
+                param.data.view.reDraw();
+            }
+        });
         (this.block.statements || []).forEach(({ view }) => view.reDraw());
         (this._extensions || []).forEach((ext) => _.result(ext, 'updatePos'));
     };

--- a/src/playground/block_view.js
+++ b/src/playground/block_view.js
@@ -1170,6 +1170,8 @@ Entry.BlockView.RENDER_MODE_TEXT = 2;
 
         this._updateContents(true);
 
+        //해당 블럭이 가진 파라미터가 다른 블럭인 경우 재귀로 동작. indicator(undefined), string 은 제외
+        (this.block.data.params || []).forEach((param) => param && param.data && param.data.view && param.data.view.reDraw());
         (this.block.statements || []).forEach(({ view }) => view.reDraw());
         (this._extensions || []).forEach((ext) => _.result(ext, 'updatePos'));
     };

--- a/src/playground/thread_view.js
+++ b/src/playground/thread_view.js
@@ -117,12 +117,15 @@ Entry.ThreadView = function(thread, board) {
     };
 
     p.reDraw = function() {
-        var blocks = this.thread._data;
+        const blocks = this.thread._data;
 
-        for (var i = blocks.length - 1; i >= 0; i--) {
-            var b = blocks[i];
-            if (b.view) b.view.reDraw();
-            else b.createView(this.thread._code.view.board);
+        for (let i = blocks.length - 1; i >= 0; i--) {
+            const b = blocks[i];
+            if (b.view) {
+                b.view.reDraw();
+            } else {
+                b.createView(this.thread._code.view.board);
+            }
         }
     };
 


### PR DESCRIPTION
블럭 파라미터의 변수변경 로직이 재귀적으로 동작하도록 수정

- 블럭 파라미터의 파라미터가 변수블럭인 경우에도 로직이 닿을 수 있도록 수정