### PR TITLE
BitBlock 확장블록 추가를 위해, ArduinoExt로 변경

### DIFF
--- a/src/playground/blocks/index.js
+++ b/src/playground/blocks/index.js
@@ -77,7 +77,7 @@ Entry.HARDWARE_LIST = {
     '2.9': Entry.Turtle,
     '2.FF': Entry.Roboid,
     '3.1': Entry.Bitbrick,
-    '4.2': Entry.Arduino,
+    '4.2': Entry.ArduinoExt,
     '5.1': Entry.Neobot,
     '5.2': Entry.NeobotSensorTheme,
     '5.3': Entry.NeobotRobotTheme,


### PR DESCRIPTION
- BitBlock 보드의 블록을 Entry.Arduino 에서 Entry.ArduinoExt 로  ([entryjs]/src/playground/blocks/index.js)
- entry-hw 의 bitblock.json과 bitblock.js 파일도 변경됨 ([entry-hw]/app/modules)