### PR TITLE
[충돌체크] 최적화: 충돌 체크 함수의 리턴을 사각형이 아닌, 점으로 리턴받음.

### DIFF
--- a/src/playground/blocks/block_judgement.js
+++ b/src/playground/blocks/block_judgement.js
@@ -134,19 +134,19 @@ module.exports = {
                         switch (targetSpriteId) {
                             case 'wall':
                                 return !!(
-                                    collision(object, wall.up, ath, true) ||
-                                    collision(object, wall.down, ath, true) ||
-                                    collision(object, wall.left, ath, true) ||
-                                    collision(object, wall.right, ath, true)
+                                    collision(object, wall.up, ath, false) ||
+                                    collision(object, wall.down, ath, false) ||
+                                    collision(object, wall.left, ath, false) ||
+                                    collision(object, wall.right, ath, false)
                                 );
                             case 'wall_up':
-                                return !!collision(object, wall.up, ath, true);
+                                return !!collision(object, wall.up, ath, false);
                             case 'wall_down':
-                                return !!collision(object, wall.down, ath, true);
+                                return !!collision(object, wall.down, ath, false);
                             case 'wall_right':
-                                return !!collision(object, wall.right, ath, true);
+                                return !!collision(object, wall.right, ath, false);
                             case 'wall_left':
-                                return !!collision(object, wall.left, ath, true);
+                                return !!collision(object, wall.left, ath, false);
                         }
                     } else if (targetSpriteId === 'mouse') {
                         const stage = Entry.stage.canvas;
@@ -178,7 +178,7 @@ module.exports = {
                         } else {
                             if (
                                 targetSprite.getVisible() &&
-                                collision(object, targetSprite.object, ath, true)
+                                collision(object, targetSprite.object, ath, false)
                             ) {
                                 return true;
                             }
@@ -188,7 +188,7 @@ module.exports = {
                                 if (entity.isStamp || !entity.getVisible()) {
                                     continue;
                                 }
-                                if (collision(object, entity.object, ath, true)) {
+                                if (collision(object, entity.object, ath, false)) {
                                     return true;
                                 }
                             }


### PR DESCRIPTION
#block_judgement.js
충돌 체크 함수의 `getRect` 인자를 true -> false 로 바꿈
`true 일때` : 충돌하는 사각형 영역을 리턴
`false 일때 ` : 충돌하는 임의의 점 ( loop 중에 발견된 첫번째 점 ) 을 리턴
`이득` : 적은 수의 loop 를 수행함으로서 성능 향상을 기대
