### PR TITLE
Issue/9582 워크스페이스 실과형 기본 블록노출 추가

### DIFF
--- a/extern/util/static_mini.js
+++ b/extern/util/static_mini.js
@@ -214,6 +214,8 @@ EntryStatic.getAllBlocks = function() {
                 'is_press_some_key',
                 'reach_something',
                 'boolean_basic_operator',
+                'boolean_and_or',
+                'boolean_not',
             ],
         },
         {


### PR DESCRIPTION
워크스페이스 실과형 

판단카테고리  기본 노출 블록 추가(type=workspace 와 동일)
 - 참 그리고 참
 - 참 또는 거짓
 - 참 (이)가 아니다 
![image](https://user-images.githubusercontent.com/38307261/49987731-c096b380-ffb7-11e8-87b5-b4365f599f4e.png)

 


