### PR TITLE
[hotfix] Issue/9810

### DIFF
--- a/src/playground/board.js
+++ b/src/playground/board.js
@@ -963,7 +963,6 @@ Entry.Board = class Board {
             const svgGroup = _.result(block && block.view, 'svgGroup');
             if (this.svgBlockGroup && svgGroup) {
                 this.svgBlockGroup.appendChild(svgGroup);
-                // block.getCode().pushBackThread(block.getThread());
             }
         });
 

--- a/src/playground/board.js
+++ b/src/playground/board.js
@@ -963,7 +963,7 @@ Entry.Board = class Board {
             const svgGroup = _.result(block && block.view, 'svgGroup');
             if (this.svgBlockGroup && svgGroup) {
                 this.svgBlockGroup.appendChild(svgGroup);
-                block.getCode().pushBackThread(block.getThread());
+                // block.getCode().pushBackThread(block.getThread());
             }
         });
 


### PR DESCRIPTION
https://oss.navercorp.com/entry/Entry/issues/9810

undo/ redo 동작 오류
  - 화면에 보이는 순서로 스레드 순서를 조절하여 발생하는 현상
  - 블록이 겹쳐져있는 상태에서 드래그로 끼워넣기할때 맨위 블록이 선택 안될 수 있음
  - 향후 thread를 index로 처리했던 부분을 id로 수정하게끔 변경해야함