### PR TITLE
Issue/9824 엔트리 콘솔창 입력가능 분기처리

### DIFF
--- a/src/textcoding/util/console.js
+++ b/src/textcoding/util/console.js
@@ -74,6 +74,9 @@ Entry.Console = function() {
     p.print = function(message, mode) {
         if (!this.visible) return;
 
+        if (mode !== 'ask') {
+            this._doc.cm.options.readOnly = 'nocursor';
+        }
         this.setEditing(true);
         this.codeMirror.execCommand('goDocEnd');
         var cursor = this._doc.getCursor();
@@ -86,6 +89,7 @@ Entry.Console = function() {
         if (mode === 'speak') this.setEditing(false);
         this.codeMirror.execCommand('goDocEnd');
         if (mode === 'ask') {
+            this._doc.cm.options.readOnly = false;
             this._doc.addLineClass(cursor.line + 1, 'text', 'answer');
             this.codeMirror.focus();
         }


### PR DESCRIPTION
1. console.js
 - 묻고 대답기다리기 블록사용시 (mode=ask) 엔트리콘솔창에 입력이 가능하도록 분기처리
 - nocursor -> false
