### PR TITLE
Issue/9870

### DIFF
--- a/src/playground/block_view.js
+++ b/src/playground/block_view.js
@@ -447,7 +447,7 @@ Entry.BlockView = class BlockView {
 
         const dblclick = _.result(this.block.events, 'dblclick');
         if (dblclick) {
-            const hammer = new Hammer(this.svgGroup);
+            const hammer = new Hammer(this.pathGroup);
             hammer.on('doubletap', () => {
                 if (this._board.readOnly) {
                     return;
@@ -458,7 +458,7 @@ Entry.BlockView = class BlockView {
                     }
                 });
             });
-            $(this.svgGroup).dblclick(() => {
+            $(this.pathGroup).dblclick(() => {
                 if (this._board.readOnly) {
                     return;
                 }


### PR DESCRIPTION
함수 블록이 연이어 조립 되어 있는 상태에서, 함수 블록 조립 화면 비정상 노출  

  - 블록 구조상 조립되어있는 상태에서 부모(위에 조립된 블럭)의 이벤트까지 발생
  - svg path를 그린 영역으로 이벤트 발생영역 조정

https://oss.navercorp.com/entry/Entry/issues/9870