### PR TITLE
Issue/9841 함수블록 위치조정

### DIFF
--- a/src/playground/skeleton.js
+++ b/src/playground/skeleton.js
@@ -600,7 +600,7 @@ Entry.skeleton.basic_param = {
     box(blockView) {
         const width = blockView ? blockView.contentWidth : 5;
         return {
-            offsetX: 0,
+            offsetX: -8,
             offsetY: 0,
             width: width + 11,
             height: 22,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38307261/50958003-ff5e5180-1502-11e9-89c3-aa37b01b9c72.png)

1. skeleton.js
- 이름(function_field_string)
- 숫자/문자(function_field_string)
- 판단값(function_field_boolean)

블록에 대해서 
skeleton.basic_param offsetX값 0 에서 -8로 변경
