### PR TITLE
조립된 블록이 있는 오브젝트에서 블록이 선택된 상태 > 그리기 화면 > 그림 복사 후 붙여넣기 시 블록도 함께 복사 및 붙여넣기 됨 #9999

### DIFF
--- a/src/playground/workspace.js
+++ b/src/playground/workspace.js
@@ -424,7 +424,8 @@ Entry.Workspace = class Workspace {
                         !isBoardReadOnly &&
                         board &&
                         board instanceof Entry.Board &&
-                        Entry.clipboard
+                        Entry.clipboard &&
+                        Entry.playground.getViewMode() === 'code'
                     ) {
                         Entry.do('addThread', Entry.clipboard)
                             .value.getFirstBlock()


### PR DESCRIPTION
#9999

"블럭"탭 에서만 블럭을 복사하도록 수정함. 