### PR TITLE
[issue/10051] Entry.Painter 의 baseUrl 선언절차 수정

### DIFF
--- a/src/class/painter.js
+++ b/src/class/painter.js
@@ -2,7 +2,7 @@
 
 Entry.Painter = function(view) {
     this.view = view;
-    this.baseUrl = Entry.painterBaseUrl || '/lib/literallycanvas-mobile/lib/img';
+    this.baseUrl = Entry.painterBaseUrl;
 
     this.file = {
         id: Entry.generateHash(),

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -34,6 +34,7 @@ Entry.init = function(container, options) {
     this.options = options;
     this.parseOptions(options);
     this.mediaFilePath = `${options.libDir ? options.libDir : '/lib'}/entry-js/images/`;
+    this.painterBaseUrl = `${options.libDir ? options.libDir : '/lib'}/literallycanvas-mobile/lib/img`;
     this.defaultPath = options.defaultDir || '';
     this.blockInjectPath = options.blockInjectDir || '';
 


### PR DESCRIPTION
entryjs 에서 painterBaseUrl 을 선언하는 부분이 없어 무조건 기본값으로 세팅되는 문제 발생

Entry init options 의 libDir 을 기준으로 literallycanvas-mobile 위치를 선정하도록 수정  
(literallycanvas-mobile 이라는 이름은 기존값에서 유지)