### PR TITLE
[executor] new Error() 대신 catch된 error throw

### DIFF
--- a/src/playground/executors.js
+++ b/src/playground/executors.js
@@ -43,7 +43,7 @@ class Executor {
                     returnVal = Entry.STATIC.BREAK;
                 } else if (this.isFuncExecutor) {
                     //function executor
-                    throw new Error();
+                    throw e;
                 } else {
                     Entry.Utils.stopProjectWithToast(this.scope, undefined, e);
                 }


### PR DESCRIPTION
어짜피 throw를 할거라면, 에러 내용이라도 알 수 있도록 catch된 error를 throw 하는게 올다고 생각함요.