### PR TITLE
[feature] 빌드 최적화

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "eslint-plugin-prettier": "^3.0.1",
         "extract-text-webpack-plugin": "^4.0.0-beta.0",
         "file-loader": "^1.1.11",
+        "hard-source-webpack-plugin": "^0.13.1",
         "jest-jenkins-reporter": "^1.0.2",
         "karma": "^4.0.0",
         "karma-chai": "^0.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "outDir": "./dist/",
+//        "outDir": "./dist/",
         "sourceMap": true,
         "noImplicitAny": true,
         "module": "esnext",
@@ -11,6 +11,10 @@
         "allowJs": true
     },
     "include": [
-        "./src/**/*"
+        "./src/class/pixi/**/*.ts",
+        "./src/class/maxrect-packer/*.ts",
+        "./src/graphicEngine/*.ts",
+        "./src/util/*.ts",
+        "./src/test.ts"
     ]
 }

--- a/webpack_config/common.js
+++ b/webpack_config/common.js
@@ -4,6 +4,7 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 module.exports = {
     entry: {
@@ -46,6 +47,13 @@ module.exports = {
             {
                 test: /\.tsx?$/,
                 loader: 'awesome-typescript-loader',
+                options: {
+                    useCache: true,
+                    cacheDirectory: path.join(__dirname, '..', 'node_modules', '.cache', 'awcache'),
+                    reportFiles: ['src/**/*.{ts,tsx}'],
+                    transpileOnly: true,
+                    useTranspileModule: true,
+                },
             },
         ],
     },
@@ -58,6 +66,17 @@ module.exports = {
         new CleanWebpackPlugin(['dist'], {
             root: path.join(__dirname, '..'),
         }),
+        new HardSourceWebpackPlugin(),
+        new HardSourceWebpackPlugin.ExcludeModulePlugin([
+            {
+                // HardSource works with mini-css-extract-plugin but due to how
+                // mini-css emits assets, assets are not emitted on repeated builds with
+                // mini-css and hard-source together. Ignoring the mini-css loader
+                // modules, but not the other css loader modules, excludes the modules
+                // that mini-css needs rebuilt to output assets every time.
+                test: /mini-css-extract-plugin[\\/]dist[\\/]loader/,
+            },
+        ]),
         new ManifestPlugin(),
         new MiniCssExtractPlugin({
             // Options similar to the same options in webpackOptions.output
@@ -66,16 +85,4 @@ module.exports = {
             chunkFilename: '[id].css',
         }),
     ],
-    // optimization: {
-    //     runtimeChunk: 'single',
-    //     // splitChunks: {
-    //     //     chunks: 'all',
-    //     //     // cacheGroups: {
-    //     //     //     vendor: {
-    //     //     //         name: 'vendors',
-    //     //     //         chunks: 'all',
-    //     //     //     },
-    //     //     // },
-    //     // },
-    // },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,11 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-indent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+  integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -4413,6 +4418,25 @@ har-validator@~5.0.3:
   dependencies:
     ajv "^5.1.0"
     har-schema "^2.0.0"
+
+hard-source-webpack-plugin@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.13.1.tgz#a99071e25b232f1438a5bc3c99f10a3869e4428e"
+  integrity sha512-r9zf5Wq7IqJHdVAQsZ4OP+dcUSvoHqDMxJlIzaE2J0TZWn3UjMMrHqwDHR8Jr/pzPfG7XxSe36E7Y8QGNdtuAw==
+  dependencies:
+    chalk "^2.4.1"
+    find-cache-dir "^2.0.0"
+    graceful-fs "^4.1.11"
+    lodash "^4.15.0"
+    mkdirp "^0.5.1"
+    node-object-hash "^1.2.0"
+    parse-json "^4.0.0"
+    pkg-dir "^3.0.0"
+    rimraf "^2.6.2"
+    semver "^5.6.0"
+    tapable "^1.0.0-beta.5"
+    webpack-sources "^1.0.1"
+    write-json-file "^2.3.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -6375,7 +6399,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.3:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.3:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6891,6 +6915,11 @@ node-notifier@^5.2.1:
     semver "^5.4.1"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-object-hash@^1.2.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.2.tgz#385833d85b229902b75826224f6077be969a9e94"
+  integrity sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ==
 
 node-pre-gyp@^0.10.0:
   version "0.10.2"
@@ -9355,6 +9384,13 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -9749,6 +9785,11 @@ table@4.0.2:
 tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
+
+tapable@^1.0.0-beta.5:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
+  integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tapable@^1.1.0:
   version "1.1.1"
@@ -10416,16 +10457,16 @@ webpack-merge@^4.1.2:
   dependencies:
     lodash "^4.17.5"
 
-webpack-sources@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
+webpack-sources@^1.0.1, webpack-sources@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
+webpack-sources@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
@@ -10563,6 +10604,15 @@ write-file-atomic@2.4.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-atomic@^2.0.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write-file-atomic@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
@@ -10570,6 +10620,18 @@ write-file-atomic@^2.1.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-json-file@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
+  integrity sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=
+  dependencies:
+    detect-indent "^5.0.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    pify "^3.0.0"
+    sort-keys "^2.0.0"
+    write-file-atomic "^2.0.0"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## PR 목적

- 타입스크립트 빌드로 인한 빌드 속도 저하를 완화
- HardSourceWebpackPlugin 으로 빌드 데이터 캐싱 -> 빌드 속도 상승기대

---

## yarn prod 빌드 타임 테스트 (각 5회씩, 본인 PC로 확인)

- 아무것도 안한 현재 상태
  - 50.70s
  - 39.70s
  - 38.86s
  - 38.21s
  - 40.14s

- awesome-typescript-loader (이하 at-loader) 에 useCache: true 옵션 추가
  - 39.17s
  - 36.01s
  - 35.85s
  - 35.73s
  - 34.93s
  - (다시 플래그 삭제 후 일반빌드시 : 38.20s)

- at-loader 에 useCache, transpileOnly, useTranspileModule 옵션 추가
  - 31.21s
  - 29.42s
  - 28.91s
  - 29.66s
  - 30.40s

- tsconfig.json include 를 현재 ts 적용중인 위치로만 한정
  - 27.66s
  - 27.86s
  - 28.23s
  - 28.21s
  - 28.28s

- HardSourceWebpackPlugin 추가 + 이전 모든설정 적용
  - 43.75s
  - 13.43s
  - 29.29s
  - 22.64s
  - 20.88s
  - 아래 테스트 후 생각해보니, css 관련 캐시 히트 실패로 발생한 빌드 속도 저하로 보입니다.

- 최종적으로, 모든 플래그 정리 / plugin 추가 / css loader exclude (캐시 히트못함) 후 캐시 전부 삭제후 테스트
  - 27.03s
  - 13.44s
  - 13.47s
  - 12.99s
  - 13.60s

---

## 참고사항

[[repo]awesome-typescript-loader](https://github.com/s-panferov/awesome-typescript-loader)
[[repo]hard-source-webpack-plugin](https://github.com/mzgoddard/hard-source-webpack-plugin)

- common webpack build 파일의 수정으로, production 빌드에 영향을 줄 수 있으므로 다음 배포에 테스트하는 것이 좋지 않을까 싶습니다.

- HardSourceWebpackPlugin 이슈로, 'Cannot read property 'hash' of undefined' 발생가능
  빌드 결과에 영향을 주지는 않을 것으로 보입니다만 최초 발생 후 주기적으로 발생합니다. 발생시 해당 빌드 조건은  
  HardSourceWebpackPlugin.ExcludeModulePlugin 의 룰에 포함시키면 됩니다.

- 캐시 디렉토리는 node_modules/.cache 입니다.
  - at-loader 캐시는 awcache
  - hard-source-webpack-plugin 캐시는 hard-source 입니다.