### PR TITLE
이슈 10471 처리

### DIFF
--- a/src/playground/field/block.js
+++ b/src/playground/field/block.js
@@ -41,9 +41,39 @@ Entry.FieldBlock = class FieldBlock extends Entry.Field {
         return _.result(this._blockView, 'getBoard');
     }
 
-    getBlockType = () => {
-        return 'field';
-    };
+    getBlockType = () => 'field';
+
+    getBlockList(excludePrimitive, type) {
+        const { value } = this;
+        try {
+            return _.chain(value.getBlockList(excludePrimitive, type))
+                .flatten()
+                .compact()
+                .value();
+        } catch (e) {
+            console.log(e);
+            return [];
+        }
+    }
+
+    stringify(excludeData, isNew) {
+        try {
+            return JSON.stringify(this.toJSON(isNew, undefined, excludeData));
+        } catch (e) {
+            console.error(e);
+            return '';
+        }
+    }
+
+    toJSON(isNew, index, excludeData, option) {
+        try {
+            const { value } = this;
+            return [value.toJSON(isNew, excludeData, option)];
+        } catch (e) {
+            console.error(e);
+            return [];
+        }
+    }
 
     renderStart(board, mode, renderMode, isReDraw) {
         if (!this.svgGroup) {


### PR DESCRIPTION
[#10471](https://oss.navercorp.com/entry/Entry/issues/10471) 처리
조립되어 있는 field블록의 경우 따로 thread가 있지 않고 field블록이 thread 역할을함.
field 블록에 비어 있는 getBlockList, stringify, toJSON 함수를 추가함.