### PR TITLE
[#295] 일본어의 경우 .이 아니라 。로 사용되고 있어 줄바꿈이 적용되지 않고 . 이 추가로 나오는 오류 수정

### DIFF
--- a/src/class/playground.js
+++ b/src/class/playground.js
@@ -70,8 +70,7 @@ Entry.Playground = class {
             const curtainView = Entry.createElement('div', 'entryCurtain')
                 .addClass('entryPlaygroundCurtainWorkspace entryRemove')
                 .appendTo(this.view_);
-            const [mentHead, mentTail = ''] = Lang.Workspace.cannot_edit_click_to_stop.split('.');
-            curtainView.innerHTML = `${mentHead}.<br/>${mentTail}`;
+            curtainView.innerHTML = Lang.Workspace.cannot_edit_click_to_stop;
             curtainView.addEventListener('click', () => {
                 Entry.engine.toggleStop();
             });


### PR DESCRIPTION
https://oss.navercorp.com/entryline/web/issues/295

<br>태그 까지 html로 보여주도록 수정.