### PR TITLE
[issue/10513][WebGL] handleDrag 이벤트 구현방식 변경

### DIFF
--- a/src/graphicEngine/GEDragHelper.ts
+++ b/src/graphicEngine/GEDragHelper.ts
@@ -1,40 +1,39 @@
-
 interface IEventType {
-    UP:string;
-    MOVE:string;
-    DOWN:string;
-    OVER:string;
+    UP: string;
+    MOVE: string;
+    DOWN: string;
+    OVER: string;
 }
 
-function getPIXIEvent():IEventType {
+function getPIXIEvent(): IEventType {
     return {
         UP: '__pointerdown',
         DOWN: '__pointermove',
         MOVE: '__pointerup',
-        OVER: 'pointerover'
+        OVER: 'pointerover',
     };
 }
 
-function getCreatejsEvent():IEventType  {
+function getCreatejsEvent(): IEventType {
     return {
         UP: 'pressup',
         DOWN: 'mousedown',
         MOVE: 'pressmove',
-        OVER: 'mouseover'
+        OVER: 'mouseover',
     };
 }
 
 
 class _GEDragHelper {
 
-    types:IEventType;
-    private _isWebGL:boolean;
-    public handleDrag:(target:any)=>void;
+    types: IEventType;
+    private _isWebGL: boolean;
+    public handleDrag: (target: any) => void;
 
-    INIT(isWebGL:boolean) {
+    INIT(isWebGL: boolean) {
         this._isWebGL = isWebGL;
         this.types = isWebGL ? getPIXIEvent() : getCreatejsEvent();
-        if(isWebGL) {
+        if (isWebGL) {
             this.types = getPIXIEvent();
             this.handleDrag = this._handleDragPIXI;
         } else {
@@ -43,30 +42,48 @@ class _GEDragHelper {
         }
     }
 
-    private _handleDragPIXI(target:any) {
+    /**
+     * @since 190705 extracold1209
+     * common / move event 는 down / up 사이에 있도록 정리
+     * as-is / 모든 이벤트 등록, down 외 up, outside, cancel 은 up
+     * to-be /
+     * 최초 이벤트는 down 만 등록
+     * down 이벤트 발생시
+     * - move, outside, up 이벤트 등록
+     * - 그러나 outside 는 최초 down 한 포인트로 이벤트 발생
+     *
+     * TODO 기존 방식이 move 중 스테이지를 벗어난 경우 cancel 을 위한 onUpEvent 라면
+     *  다른 방법(스테이지안에 포인터가 있는것인지 체크)으로 확인해야 할 것같음.
+     *  현재 블록코딩시 webGL 을 사용하지 않고, minimize 에서는 move event 없으므로 개선보류
+     */
+    private _handleDragPIXI(target: any) {
         const C = this.types;
         const CE = this._convertPIXIEventToCreateJsStyle;
 
-        function _onMove(e:any){
+        function _onMove(e: any) {
             target.emit(C.MOVE, CE(e));
         }
 
-        function _onUp(e:any){
+        function _onUp(e: any) {
             target.emit(C.UP, CE(e));
-            target.off("pointermove", _onMove);
+            target.removeAllListeners('pointermove');
+            target.removeAllListeners('pointerup');
+            target.removeAllListeners('pointerupoutside');
         }
 
-        function _onDown(e:any) {
+        function _onDown(e: any) {
             target.emit(C.DOWN, CE(e));
-            target.on("pointermove", _onMove);
+            target.on('pointermove', _onMove);
+            target.on('pointerupoutside', () => {
+                _onUp(e);
+            });
+            target.on('pointerup', _onUp);
         }
 
-        target.on("pointerdown", _onDown);
-        target.on("pointerup", _onUp);
-        target.on("pointerupoutside", _onUp);
-        target.on("pointercancel", _onUp);
+        target.on('pointerdown', _onDown);
     }
-    private _convertPIXIEventToCreateJsStyle(e:any) {
+
+    private _convertPIXIEventToCreateJsStyle(e: any) {
         let g = e.data.global;
         return {
             target: e.target,
@@ -74,11 +91,11 @@ class _GEDragHelper {
             stageX: g.x,
             stageY: g.y,
             rawX: g.x,
-            rawY: g.y
+            rawY: g.y,
         };
     }
 
-    private _handleCreateJs(target:any) {
+    private _handleCreateJs(target: any) {
         //do nothing;
     }
 


### PR DESCRIPTION
- 이슈는 A obj mouseUp 후, scene 전환 후 클릭에서 B obj mouseDown
  과 A obj pointerupoustide 이벤트가 mouseUp 으로 동작하면서 발생한 이슈

## as-is

down, (up, outside, cancel) = up 으로 이벤트 등록

## to-be

down 만 등록 후, down 시 모든 이벤트 활성화
up 시 down 을 제외한 모든 이벤트 비활성화

- 추가로 마우스 위에서 클릭 한 후, 다른 위치에서 마우스 업 되었을때 초기 포인터 위치로 up 이벤트가 발생하도록 처리했습니다. createjs 현재 스펙과 동일하게 맞추기 위함입니다.