### PR TITLE
[Issue/10686] 하드웨어 모니터 템플릿 다국어 적용 정책 수정

### DIFF
--- a/src/class/hw_monitor.js
+++ b/src/class/hw_monitor.js
@@ -51,7 +51,10 @@ Entry.HWMonitor = class HardwareMonitor {
             w: [],
         };
 
-        const monitorTemplate = this._hwModule.monitorTemplate;
+        let monitorTemplate = this._hwModule.monitorTemplate;
+        if (typeof this._hwModule.monitorTemplate === 'function') {
+            monitorTemplate = this._hwModule.monitorTemplate();
+        }
 
         const imgObj = {
             href: monitorTemplate.imgPath

--- a/src/playground/blocks/hardware/block_turtle.js
+++ b/src/playground/blocks/hardware/block_turtle.js
@@ -159,7 +159,7 @@ Entry.Turtle = {
         en: 'Turtle',
         ko: '거북이',
     },
-    monitorTemplate: {
+    monitorTemplate: () => ({
         imgPath: 'hw/turtle.png',
         width: 480,
         height: 354,
@@ -233,7 +233,7 @@ Entry.Turtle = {
             },
         },
         mode: 'both',
-    },
+    }),
 };
 
 Entry.Turtle.setLanguage = () => ({


### PR DESCRIPTION
as-is
- 하드웨어 모듈 Object 내
monitorTemplate property 는 무조건 object 여야 했음.
- 그렇기 때문에 해당 프로퍼티가 사용하는 Lang 다국어 데이터는 setLanguage의 데이터가 적용되기 전 평가되므로 undefined 가 될 수 있음

to-be
- 하드웨어 다국어적용 함수인 setLanguage 적용 후 평가된 데이터를 사용해야 하면 monitorTemplate 프로퍼티의 값을 함수로 작성할 수 있도록 수정