### PR TITLE
[issue/line/33] basic_text skeleton 내 multiline 적용 외 1

### DIFF
--- a/src/css/components/block.less
+++ b/src/css/components/block.less
@@ -38,6 +38,14 @@
     fill: none;
 }
 
+.block.basicTextLight {
+    cursor: default;
+}
+
+.block.basicTextLight > g > text > tspan {
+    font-weight: lighter;
+}
+
 .block {
     cursor: url('/media/handopen.cur'), auto;
     -ms-touch-action: none;

--- a/src/playground/block_entry.js
+++ b/src/playground/block_entry.js
@@ -261,6 +261,25 @@ function getBlocks() {
             },
         },
         //region hardware 하드웨어 기본
+        arduino_noti_light: {
+            skeleton: 'basic_text_light',
+            color: EntryStatic.colorSet.common.TRANSPARENT,
+            template: '%1',
+            params: [
+                {
+                    type: 'Text',
+                    text: Lang.Blocks.arduino_noti_text_light,
+                    color: EntryStatic.colorSet.common.BUTTON,
+                    align: 'center',
+                },
+            ],
+            def: {
+                type: 'arduino_noti_light',
+            },
+            class: 'arduino_default_noti',
+            isNotFor: ['arduinoDisconnected'],
+            events: {},
+        },
         arduino_noti: {
             skeleton: 'basic_text',
             color: EntryStatic.colorSet.common.TRANSPARENT,

--- a/src/playground/skeleton/basic/basic_text_light.js
+++ b/src/playground/skeleton/basic/basic_text_light.js
@@ -1,6 +1,9 @@
 const { get: _get } = require('lodash');
 
-Entry.skeleton.basic_text = {
+/**
+ * line entry 의 hardware font-light-weight noti 를 위해 만든 스켈레톤
+ */
+Entry.skeleton.basic_text_light = {
     path(blockView) {
         const paramText = _get(blockView, ['_schema', 'params', '0', 'text'], '').match(/[\r\n]/g);
         const textLines = paramText ? paramText.length + 1 : 1;
@@ -41,5 +44,5 @@ Entry.skeleton.basic_text = {
     movable: false,
     readOnly: true,
     nextShadow: false,
-    classes: ['basicText'],
+    classes: ['basicTextLight'],
 };


### PR DESCRIPTION
- basic_text skeleton 이 적용된 블록의 param text 가 multiline 인 경우
  실제 box 는 single line 크기로 적용되고있었음
- 그래서 text 아래 블록을 multiline text 가 침범하는 문제

- 특정 구조의 block param 이 multiline 인 경우 height 조정

- font-weight: bold 가 아닌 text skeleton 추가
  - 해당 로직은 text_skeleton 으로 모은 후 스타일 적용으로 개선필요