### PR TITLE
[#140] 일본어일 경우 초시계 위치가 오른쪽으로 많이 들어가 있어 글자 길이로 읽도록 수정.

### DIFF
--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -2200,6 +2200,7 @@ Entry.VariableContainer = class VariableContainer {
     }
 
     generateTimer(timer) {
+        const x = 240 - (Lang.Workspace.Variable_Timer.length * 12 + 70);
         timer =
             timer ||
             Entry.Variable.create({
@@ -2208,7 +2209,7 @@ Entry.VariableContainer = class VariableContainer {
                 value: 0,
                 variableType: 'timer',
                 visible: false,
-                x: 134,
+                x,
                 y: -70,
             });
 


### PR DESCRIPTION
 https://oss.navercorp.com/entryline/lineentry/issues/140

 - invisibleCanvas 를 사용하기엔 비용이 클 것 같아 임의의 값으로 처리
  - 오른쪽 위치 - (글자 길이 * 폰트크기 +  x ) = 134  가 되도록. x 조정.