### PR TITLE
[feature] 교과형 하드웨어 버튼의 순서 변경

### DIFF
--- a/extern/util/static_mini.js
+++ b/extern/util/static_mini.js
@@ -355,13 +355,13 @@ EntryStatic.getAllBlocks = function() {
         {
             category: 'hw_robot',
             blocks: [
-                'arduino_download_connector',
-                'download_guide',
-                'arduino_connected',
-                'arduino_connect',
                 'robot_reconnect',
                 'arduino_open',
                 'arduino_cloud_pc_open',
+                'arduino_connect',
+                'arduino_download_connector',
+                'download_guide',
+                'arduino_connected',
             ],
         },
         {


### PR DESCRIPTION
- 일반형 하드웨어 개선 사항 반영 후 교과형에 수정을 하지 않아
  순서가 틀어진 문제 발생 -> 수정