### PR TITLE
[Issue/line/248] 초시계 블럭을 가진 오브젝트가 바로 삭제된 경우 초시계 삭제로직 수행처리

### DIFF
--- a/src/class/container.js
+++ b/src/class/container.js
@@ -464,6 +464,7 @@ Entry.Container = class Container {
         object.destroy();
         objects.splice(index, 1);
         Entry.variableContainer.removeLocalVariables(object.id);
+        Entry.engine.hideProjectTimer();
 
         if (isPass === true) {
             return;

--- a/src/class/container.js
+++ b/src/class/container.js
@@ -450,11 +450,6 @@ Entry.Container = class Container {
         }
     }
 
-    /**
-     * Delete object
-     * @param {!Entry.EntryObject} object
-     * @return {Entry.State}
-     */
     removeObject(id, isPass) {
         const objects = this.objects_;
 


### PR DESCRIPTION
초시계 블럭 삭제 로직은 해당 블럭들의 viewDestroy 이벤트에 부착되어있기 때문에
바로 오브젝트를 삭제하는 경우 각 블록의 viewDestroy 호출이 되지 않음.
그래서 오브젝트 삭제시 로직에도 초시계 블럭 삭제 로직 부착

로직 자체에 모든 오브젝트를 가져와 초시계 블럭을 사용하는 개체가 있는지 판단하고 있습니다.