### PR TITLE
Issue/line/442 학습완료 작품에 대한 재시작 버튼기능 추가

### DIFF
--- a/src/class/engine.js
+++ b/src/class/engine.js
@@ -694,7 +694,12 @@ Entry.Engine = class Engine {
             if (this.pauseButtonFull) {
                 this.pauseButtonFull.innerHTML = Lang.Workspace.restart;
                 if (this.option !== 'minimize') {
-                    this.pauseButtonFull.removeClass('entryPauseButtonWorkspace_full');
+                    // workspace && buttonWrapper check
+                    if (this.buttonWrapper) {
+                        this.pauseButtonFull.addClass('entryPauseButtonWorkspace_full');
+                    } else {
+                        this.pauseButtonFull.removeClass('entryPauseButtonWorkspace_full');
+                    }
                     this.pauseButtonFull.addClass('entryRestartButtonWorkspace_full');
                 }
             }


### PR DESCRIPTION
init() 옵션에 따라 재시작/시작 버튼이 동작되도록 하는기능..확인필요


1 강의 워크 스페이스
 - 학습완료, 학습완료 버튼 클릭시 완성작품 팝업에서 시작-> 일시정지시 재시작 버튼이 나타나지 않던 부분 수정
 - engine.js > this.buttonWrapper 값있는 경우에는 재실행 버튼이 removeClass 되지 않도록 분기처리

https://oss.navercorp.com/entryline/web/issues/741