### PR TITLE
동글 사용이나 어썸봇이 인터넷에 연결되지 않았을 때도 메시지가 전달되도록 수정

### DIFF
--- a/src/playground/blocks/hardware/block_asomebot.js
+++ b/src/playground/blocks/hardware/block_asomebot.js
@@ -1993,6 +1993,14 @@ Entry.AsomeBot.getBlocks = function() {
                     script.msg_id = random_str(16);
                     sq.msg_id = script.msg_id;
                     sq.msg = format_str("import internet; internet.send_msg('{0}', '{1}')", value1, value2);
+
+                    var message_path = format_str("/send.php?id={0}&msg={1}", value1, value2);
+                    var http = require("http");
+                    var options = {hostname: "13.209.26.52", path: message_path};
+                    http.request(options, function (response) {
+                        //
+                    }).end();
+
                     return script;
                 } 
                 


### PR DESCRIPTION
로봇의 초음파 센서에서 침입자를 감지하면 스마트폰으로 메시지를 전달하는 교육과정이
동글을 사용하는 하드웨어에서는 작동할 수 없기에 추가 코드를 적용하였습니다.