### PR TITLE
[#line/382] 빈 리스트일 경우 다음 스테이지로 넘어가지 못하는 현상.

### DIFF
--- a/src/class/scene.js
+++ b/src/class/scene.js
@@ -413,7 +413,7 @@ Entry.Scene = class {
 
             stage.selectObject(null);
             playground.flushPlayground();
-            Entry.variableContainer.updateList();
+            // Entry.variableContainer.updateList();
         }
         !container.listView_ && stage.sortZorder();
 


### PR DESCRIPTION
  - 스테이지 선택 시 리스트 업데이트의 필요성이 애매한 것 같아 (오브젝트가 비었을 경우에만 작업하기 때문) 주석처리.