### PR TITLE
entryline/issue/443 하드웨어 다운로드 링크 관련 수정

### DIFF
--- a/src/class/hw.ts
+++ b/src/class/hw.ts
@@ -497,6 +497,11 @@ class Hardware implements Entry.Hardware {
     }
 
     downloadConnector() {
+        const download = Entry.events_.hwDownload;
+        //hardware download link가 n개 생겼을경우 첫번째것으로 변경
+        if (download && download.length > 1) {
+            Entry.events_.hwDownload = download.slice(0, 1);
+        }
         Entry.dispatchEvent('hwDownload', 'hardware');
     }
 
@@ -823,6 +828,7 @@ class Hardware implements Entry.Hardware {
                     hw.popupHelper.hide('hwDownload');
                 });
 
+                console.log(content);
                 popup.append(content);
             },
         });

--- a/src/class/hw.ts
+++ b/src/class/hw.ts
@@ -828,7 +828,6 @@ class Hardware implements Entry.Hardware {
                     hw.popupHelper.hide('hwDownload');
                 });
 
-                console.log(content);
                 popup.append(content);
             },
         });


### PR DESCRIPTION
https://oss.navercorp.com/entryline/lineentry/issues/433

1. hw download link가 n 개 생성시 한개의 링크만 유지되도록 수정

