### PR TITLE
[#11161] 특정 오브젝트에서 사용하는 변수 선택시 변수를 사용하는 블럭을 다른 오브젝트에 복사 붙여넣을 경우 오류.

### DIFF
--- a/src/command/commands/playground.js
+++ b/src/command/commands/playground.js
@@ -8,6 +8,8 @@
 
     c[COMMAND_TYPES.playgroundChangeViewMode] = {
         do(newType, oldType) {
+            Entry.variableContainer.selected = null;
+            Entry.variableContainer.updateList();
             Entry.playground.changeViewMode(newType);
             if (Entry.disposeEvent) {
                 Entry.disposeEvent.notify();


### PR DESCRIPTION
  -> 탭 이동시 선택을 풀도록 설정.