### PR TITLE
[security] serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.0.tgz",
             "integrity": "sha512-7pvAdC4B+iKjFFp9Ztj0QgBndJ++qaMeonT185wAqUnhipw8idm9Rv1UMyBuKtYjfl6ORNkgEgcsYLfHX/GpLw==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "@babel/generator": "^7.2.0",
@@ -38,7 +37,6 @@
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -47,9 +45,195 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
                     "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-                    "dev": true,
                     "requires": {
                         "minimist": "^1.2.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+            "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+            "requires": {
+                "@babel/types": "^7.6.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.13",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+            "integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+            "integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+            "integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
                     }
                 },
                 "ms": {
@@ -66,88 +250,267 @@
                 }
             }
         },
-        "@babel/generator": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-            "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
+            "integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
+            "dev": true,
             "requires": {
-                "@babel/types": "^7.6.0",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/helper-function-name": "^7.7.4",
+                "@babel/helper-member-expression-to-functions": "^7.7.4",
+                "@babel/helper-optimise-call-expression": "^7.7.4",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.7.4",
+                "@babel/helper-split-export-declaration": "^7.7.4"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
                 }
             }
         },
-        "@babel/helper-annotate-as-pure": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+            "integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-            "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "@babel/helper-call-delegate": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-            "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
-            }
-        },
-        "@babel/helper-create-class-features-plugin": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
-            "integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-member-expression-to-functions": "^7.5.5",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5",
-                "@babel/helper-split-export-declaration": "^7.4.4"
+                "@babel/helper-regex": "^7.4.4",
+                "regexpu-core": "^4.6.0"
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-            "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+            "integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.5.5",
+                "@babel/helper-function-name": "^7.7.4",
+                "@babel/types": "^7.7.4",
                 "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-            "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+            "integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-function-name": {
@@ -169,53 +532,144 @@
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-            "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+            "integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-            "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+            "integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.5.5"
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+            "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-            "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+            "version": "7.7.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+            "integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/template": "^7.4.4",
-                "@babel/types": "^7.5.5",
+                "@babel/helper-module-imports": "^7.7.4",
+                "@babel/helper-simple-access": "^7.7.4",
+                "@babel/helper-split-export-declaration": "^7.7.4",
+                "@babel/template": "^7.7.4",
+                "@babel/types": "^7.7.4",
                 "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+            "integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-plugin-utils": {
@@ -233,38 +687,286 @@
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-            "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+            "integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-wrap-function": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.7.4",
+                "@babel/helper-wrap-function": "^7.7.4",
+                "@babel/template": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-            "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+            "integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.5.5",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.5.5",
-                "@babel/types": "^7.5.5"
+                "@babel/helper-member-expression-to-functions": "^7.7.4",
+                "@babel/helper-optimise-call-expression": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-            "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+            "integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/template": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -276,25 +978,242 @@
             }
         },
         "@babel/helper-wrap-function": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-            "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+            "integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.2.0"
+                "@babel/helper-function-name": "^7.7.4",
+                "@babel/template": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
             }
         },
         "@babel/helpers": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-            "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+            "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
             "requires": {
-                "@babel/template": "^7.6.0",
-                "@babel/traverse": "^7.6.0",
-                "@babel/types": "^7.6.0"
+                "@babel/template": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@babel/types": "^7.7.4"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+                    "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+                    "requires": {
+                        "@babel/types": "^7.7.4",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+                    "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.7.4",
+                        "@babel/helper-function-name": "^7.7.4",
+                        "@babel/helper-split-export-declaration": "^7.7.4",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+                }
             }
         },
         "@babel/highlight": {
@@ -305,29 +1224,22 @@
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
                 "js-tokens": "^4.0.0"
-            },
-            "dependencies": {
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-                }
             }
         },
         "@babel/parser": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-            "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+            "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-            "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+            "integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0",
-                "@babel/plugin-syntax-async-generators": "^7.2.0"
+                "@babel/helper-remap-async-to-generator": "^7.7.4",
+                "@babel/plugin-syntax-async-generators": "^7.7.4"
             }
         },
         "@babel/plugin-proposal-class-properties": {
@@ -341,13 +1253,13 @@
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-            "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+            "integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.2.0"
+                "@babel/plugin-syntax-json-strings": "^7.7.4"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -361,13 +1273,13 @@
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-            "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+            "integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+                "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
             }
         },
         "@babel/plugin-proposal-private-methods": {
@@ -381,20 +1293,19 @@
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
-            "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+            "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-            "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+            "integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -410,9 +1321,9 @@
             }
         },
         "@babel/plugin-syntax-json-strings": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-            "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+            "integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -427,47 +1338,47 @@
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-            "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+            "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-            "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+            "integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-            "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+            "integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-module-imports": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0"
+                "@babel/helper-remap-async-to-generator": "^7.7.4"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-            "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+            "integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
-            "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+            "integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -475,104 +1386,212 @@
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-            "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+            "integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-define-map": "^7.5.5",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-annotate-as-pure": "^7.7.4",
+                "@babel/helper-define-map": "^7.7.4",
+                "@babel/helper-function-name": "^7.7.4",
+                "@babel/helper-optimise-call-expression": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5",
-                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/helper-replace-supers": "^7.7.4",
+                "@babel/helper-split-export-declaration": "^7.7.4",
                 "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+                    "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-            "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+            "integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-            "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+            "integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
-            "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+            "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-            "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+            "integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-            "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+            "integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-            "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+            "integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-            "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+            "integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-function-name": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0"
+            },
+            "dependencies": {
+                "@babel/helper-function-name": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+                    "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.7.4",
+                        "@babel/template": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.7.7",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+                    "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+                    "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.7.4",
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-literals": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-            "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+            "integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-            "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+            "version": "7.7.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+            "integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-module-transforms": "^7.7.5",
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             }
@@ -590,30 +1609,30 @@
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-            "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+            "integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
+                "@babel/helper-hoist-variables": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-            "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+            "integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-module-transforms": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-new-target": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-            "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+            "integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -629,30 +1648,52 @@
             }
         },
         "@babel/plugin-transform-object-super": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-            "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+            "integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5"
+                "@babel/helper-replace-supers": "^7.7.4"
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-            "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+            "integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.4.4",
-                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-call-delegate": "^7.7.4",
+                "@babel/helper-get-function-arity": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0"
+            },
+            "dependencies": {
+                "@babel/helper-get-function-arity": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+                    "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.7.4"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+                    "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-            "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+            "version": "7.7.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+            "integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
             "dev": true,
             "requires": {
                 "regenerator-transform": "^0.14.0"
@@ -671,27 +1712,27 @@
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-            "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+            "integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
-            "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+            "integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-            "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+            "integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -699,33 +1740,32 @@
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-            "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+            "integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-annotate-as-pure": "^7.7.4",
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-            "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+            "integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
-            "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+            "integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/preset-env": {
@@ -794,13 +1834,6 @@
                 "@babel/code-frame": "^7.0.0",
                 "@babel/parser": "^7.6.0",
                 "@babel/types": "^7.6.0"
-            },
-            "dependencies": {
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                }
             }
         },
         "@babel/traverse": {
@@ -819,11 +1852,6 @@
                 "lodash": "^4.17.13"
             },
             "dependencies": {
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -847,6 +1875,13 @@
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.13",
                 "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+                }
             }
         },
         "@egjs/component": {
@@ -914,32 +1949,6 @@
                 "strip-ansi": "^5.0.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -997,14 +2006,6 @@
                         "wrap-ansi": "^5.1.0"
                     }
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "is-generator-fn": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
@@ -1027,13 +2028,6 @@
                         "@babel/types": "^7.4.0",
                         "istanbul-lib-coverage": "^2.0.5",
                         "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
                     }
                 },
                 "jest-changed-files": {
@@ -1180,14 +2174,6 @@
                         "yargs": "^13.3.0"
                     }
                 },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
                 "load-json-file": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -1198,11 +2184,6 @@
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "path-type": {
                     "version": "3.0.0",
@@ -1231,20 +2212,10 @@
                         "read-pkg": "^3.0.0"
                     }
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -1343,44 +2314,6 @@
                 "string-length": "^2.0.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    },
-                    "dependencies": {
-                        "@babel/parser": {
-                            "version": "7.6.0",
-                            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                            "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                        },
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "source-map": {
-                            "version": "0.5.7",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                        }
-                    }
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -1633,14 +2566,6 @@
                         "supports-color": "^6.1.0"
                     }
                 },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
                 "load-json-file": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -1693,16 +2618,6 @@
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -1783,32 +2698,6 @@
                 "jest-runtime": "^24.9.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -1866,14 +2755,6 @@
                         "wrap-ansi": "^5.1.0"
                     }
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "is-generator-fn": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
@@ -1896,13 +2777,6 @@
                         "@babel/types": "^7.4.0",
                         "istanbul-lib-coverage": "^2.0.5",
                         "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
                     }
                 },
                 "jest-config": {
@@ -2029,14 +2903,6 @@
                         "yargs": "^13.3.0"
                     }
                 },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
                 "load-json-file": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -2047,11 +2913,6 @@
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "path-type": {
                     "version": "3.0.0",
@@ -2080,20 +2941,10 @@
                         "read-pkg": "^3.0.0"
                     }
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -2166,39 +3017,6 @@
                 "write-file-atomic": "2.4.1"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.5.7",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                        }
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "babel-plugin-istanbul": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -2208,14 +3026,6 @@
                         "find-up": "^3.0.0",
                         "istanbul-lib-instrument": "^3.3.0",
                         "test-exclude": "^5.2.3"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
                     }
                 },
                 "istanbul-lib-coverage": {
@@ -2235,21 +3045,6 @@
                         "@babel/types": "^7.4.0",
                         "istanbul-lib-coverage": "^2.0.5",
                         "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
-                },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
                     }
                 },
                 "load-json-file": {
@@ -2262,11 +3057,6 @@
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "path-type": {
                     "version": "3.0.0",
@@ -2294,6 +3084,11 @@
                         "find-up": "^3.0.0",
                         "read-pkg": "^3.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "test-exclude": {
                     "version": "5.2.3",
@@ -2341,9 +3136,9 @@
             }
         },
         "@types/babel__generator": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-            "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+            "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
             "requires": {
                 "@babel/types": "^7.0.0"
             }
@@ -2358,9 +3153,9 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
-            "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
+            "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
             "requires": {
                 "@babel/types": "^7.3.0"
             }
@@ -2410,10 +3205,19 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/jquery": {
+            "version": "3.3.31",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+            "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+            "dev": true,
+            "requires": {
+                "@types/sizzle": "*"
+            }
+        },
         "@types/json-schema": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-            "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+            "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
             "dev": true
         },
         "@types/lodash": {
@@ -2435,15 +3239,27 @@
             "dev": true
         },
         "@types/pixi.js": {
-            "version": "4.8.8",
-            "resolved": "https://registry.npmjs.org/@types/pixi.js/-/pixi.js-4.8.8.tgz",
-            "integrity": "sha512-5wmLnmL3foK/rqYMrrEM/3DxEwvwxJaP73RyqY8aMqq8zUm6CBlmc+12RIBH6iR/RHqU76XL238vWWJV1IN/zw==",
+            "version": "4.8.9",
+            "resolved": "https://registry.npmjs.org/@types/pixi.js/-/pixi.js-4.8.9.tgz",
+            "integrity": "sha512-PCqd9/TaGOAqg73u8cQKH2sg8pdkRzU6VKu8lWrV+/+p5QiDRtrT8chY5yveVM8A/hWLNtvIQlWpojDomTSNQQ==",
             "dev": true
         },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+            "dev": true
+        },
+        "@types/sizzle": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+            "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+            "dev": true
+        },
+        "@types/socket.io-client": {
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.32.tgz",
+            "integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -2458,9 +3274,9 @@
             "dev": true
         },
         "@types/yargs": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
-            "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+            "version": "13.0.4",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
+            "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
             "requires": {
                 "@types/yargs-parser": "*"
             }
@@ -2471,68 +3287,40 @@
             "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.0.tgz",
-            "integrity": "sha512-34BAFpNOwHXeqT+AvdalLxOvcPYnCxA5JGmBAFL64RGMdP0u65rXjii7l/nwpgk5aLEE1LaqF+SsCU0/Cb64xA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.0.tgz",
+            "integrity": "sha512-ry+fgd0Hh33LyzS30bIhX/a1HJpvtnecjQjWxxsZTavrRa1ymdmX7tz+7lPrPAxB018jnNzwNtog6s3OhxPTAg==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "2.6.0",
+                "@typescript-eslint/typescript-estree": "2.3.0",
                 "eslint-scope": "^5.0.0"
-            },
-            "dependencies": {
-                "eslint-scope": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-                    "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.0.tgz",
-            "integrity": "sha512-AvLejMmkcjRTJ2KD72v565W4slSrrzUIzkReu1JN34b8JnsEsxx7S9Xx/qXEuMQas0mkdUfETr0j3zOhq2DIqQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.3.0.tgz",
+            "integrity": "sha512-Dc+LAtHts0yDuusxG0NVjGvrpPy2kZauxqPbfFs0fmcMB4JhNs+WwIDMFGWeKjbGoPt/SIUC9XJ7E0ZD/f8InQ==",
             "dev": true,
             "requires": {
                 "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "2.6.0",
-                "@typescript-eslint/typescript-estree": "2.6.0",
+                "@typescript-eslint/experimental-utils": "2.3.0",
+                "@typescript-eslint/typescript-estree": "2.3.0",
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
-            "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.0.tgz",
+            "integrity": "sha512-WBxfwsTeCOsmQ7cLjow7lgysviBKUW34npShu7dxJYUQCbSG5nfZWZTgmQPKEc+3flpbSM7tjXjQOgETYp+njQ==",
             "dev": true,
             "requires": {
-                "debug": "^4.1.1",
                 "glob": "^7.1.4",
                 "is-glob": "^4.0.1",
                 "lodash.unescape": "4.0.1",
                 "semver": "^6.3.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2710,9 +3498,9 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "abab": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
-            "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
         },
         "accepts": {
             "version": "1.3.7",
@@ -2725,35 +3513,31 @@
             }
         },
         "acorn": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-            "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "acorn-globals": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-            "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
             "requires": {
                 "acorn": "^6.0.1",
                 "acorn-walk": "^6.0.1"
-            }
-        },
-        "acorn-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-            "dev": true,
-            "requires": {
-                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                    "dev": true
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+                    "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
                 }
             }
+        },
+        "acorn-jsx": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+            "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+            "dev": true
         },
         "acorn-walk": {
             "version": "6.2.0",
@@ -2811,9 +3595,9 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -3065,9 +3849,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+            "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -3080,12 +3864,6 @@
                 "js-tokens": "^3.0.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -3105,14 +3883,11 @@
                         "supports-color": "^2.0.0"
                     }
                 },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "2.0.0",
@@ -3149,12 +3924,6 @@
                 "source-map": "^0.5.7"
             },
             "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                },
                 "slash": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -3420,14 +4189,6 @@
                 "babel-types": "^6.26.0",
                 "babylon": "^6.18.0",
                 "lodash": "^4.17.4"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                }
             }
         },
         "babel-traverse": {
@@ -3447,12 +4208,6 @@
                 "lodash": "^4.17.4"
             },
             "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                },
                 "globals": {
                     "version": "9.18.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -3480,6 +4235,12 @@
                     "dev": true
                 }
             }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
         },
         "backo2": {
             "version": "1.0.2",
@@ -3752,17 +4513,17 @@
             }
         },
         "bser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-            "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "requires": {
                 "node-int64": "^0.4.0"
             }
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -4006,12 +4767,38 @@
                 "path-is-absolute": "^1.0.0",
                 "readdirp": "^2.2.1",
                 "upath": "^1.1.1"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+                }
             }
         },
         "chownr": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-            "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
         },
         "chrome-trace-event": {
             "version": "1.0.2",
@@ -4126,12 +4913,12 @@
             }
         },
         "cli-cursor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "^3.1.0"
             }
         },
         "cli-width": {
@@ -4149,6 +4936,33 @@
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "clone": {
@@ -4222,9 +5036,9 @@
             }
         },
         "colors": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-            "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
             "dev": true
         },
         "combined-stream": {
@@ -4236,15 +5050,9 @@
             }
         },
         "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
-        },
-        "common-tags": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-            "dev": true
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "commondir": {
             "version": "1.0.1",
@@ -4341,12 +5149,9 @@
             "dev": true
         },
         "console-browserify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-            "requires": {
-                "date-now": "^0.1.4"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -4553,9 +5358,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
-                    "integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -4593,21 +5398,13 @@
             "dev": true
         },
         "css-tree": {
-            "version": "1.0.0-alpha.33",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-            "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+            "version": "1.0.0-alpha.37",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+            "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
             "dev": true,
             "requires": {
                 "mdn-data": "2.0.4",
-                "source-map": "^0.5.3"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
+                "source-map": "^0.6.1"
             }
         },
         "css-unit-converter": {
@@ -4705,36 +5502,12 @@
             "dev": true
         },
         "csso": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-            "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+            "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
             "dev": true,
             "requires": {
-                "css-tree": "1.0.0-alpha.29"
-            },
-            "dependencies": {
-                "css-tree": {
-                    "version": "1.0.0-alpha.29",
-                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-                    "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
-                    "dev": true,
-                    "requires": {
-                        "mdn-data": "~1.1.0",
-                        "source-map": "^0.5.3"
-                    }
-                },
-                "mdn-data": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-                    "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
+                "css-tree": "1.0.0-alpha.37"
             }
         },
         "cssom": {
@@ -4790,9 +5563,9 @@
             },
             "dependencies": {
                 "whatwg-url": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-                    "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
                     "requires": {
                         "lodash.sortby": "^4.7.0",
                         "tr46": "^1.0.1",
@@ -4806,11 +5579,6 @@
             "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
             "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
             "dev": true
-        },
-        "date-now": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
         "debug": {
             "version": "2.6.9",
@@ -4848,9 +5616,9 @@
             }
         },
         "deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-            "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
             "dev": true,
             "requires": {
                 "is-arguments": "^1.0.4",
@@ -4948,9 +5716,9 @@
             "dev": true
         },
         "des.js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
             "requires": {
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
@@ -5011,12 +5779,6 @@
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
             }
-        },
-        "dlv": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true
         },
         "dns-equal": {
             "version": "1.0.0",
@@ -5159,14 +5921,14 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.254",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.254.tgz",
-            "integrity": "sha512-7I5/OkgR6JKy6RFLJeru0kc0RMmmMu1UnkHBKInFKRrg1/4EQKIqOaUqITSww/SZ1LqWwp1qc/LLoIGy449eYw=="
+            "version": "1.3.322",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+            "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
         },
         "elliptic": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
-            "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
             "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -5202,9 +5964,9 @@
             }
         },
         "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
                 "once": "^1.4.0"
             }
@@ -5332,9 +6094,9 @@
             }
         },
         "es-to-primitive": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -5342,14 +6104,14 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.51",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-            "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
             "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "^1.0.0"
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
             }
         },
         "es6-iterator": {
@@ -5364,13 +6126,13 @@
             }
         },
         "es6-symbol": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-            "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
             "dev": true,
             "requires": {
                 "d": "^1.0.1",
-                "es5-ext": "^0.10.51"
+                "ext": "^1.1.2"
             }
         },
         "escape-html": {
@@ -5448,18 +6210,6 @@
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-                    "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-                    "dev": true
-                },
-                "acorn-jsx": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-                    "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
-                    "dev": true
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -5475,49 +6225,10 @@
                         "ms": "^2.1.1"
                     }
                 },
-                "eslint-scope": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-                    "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                },
-                "eslint-utils": {
-                    "version": "1.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-                    "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-                    "dev": true,
-                    "requires": {
-                        "eslint-visitor-keys": "^1.1.0"
-                    }
-                },
-                "espree": {
-                    "version": "6.1.2",
-                    "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-                    "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "^7.1.0",
-                        "acorn-jsx": "^5.1.0",
-                        "eslint-visitor-keys": "^1.1.0"
-                    }
-                },
-                "glob-parent": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-                    "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
-                },
                 "import-fresh": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-                    "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+                    "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
                     "dev": true,
                     "requires": {
                         "parent-module": "^1.0.0",
@@ -5550,52 +6261,34 @@
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
-                },
-                "strip-json-comments": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-                    "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-                    "dev": true
                 }
             }
         },
         "eslint-config-prettier": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.2.0.tgz",
-            "integrity": "sha512-VLsgK/D+S/FEsda7Um1+N8FThec6LqE3vhcMyp8mlmto97y3fGf3DX7byJexGuOb1QY0Z/zz222U5t+xSfcZDQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+            "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
             "dev": true,
             "requires": {
                 "get-stdin": "^6.0.0"
             }
         },
         "eslint-loader": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.2.tgz",
-            "integrity": "sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.0.tgz",
+            "integrity": "sha512-rdxyQ0i9VlhwVlR6oEzrIft8WNKYSD2/cOAJ1YVH/F76gAta7Zv1Dr5xJOUyx0fAsHB5cKNz9hwlUVLMFsQlPA==",
             "dev": true,
             "requires": {
-                "fs-extra": "^8.1.0",
                 "loader-fs-cache": "^1.0.2",
                 "loader-utils": "^1.2.3",
                 "object-hash": "^1.3.1",
-                "schema-utils": "^2.2.0"
+                "schema-utils": "^2.1.0"
             },
             "dependencies": {
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
                 "schema-utils": {
-                    "version": "2.5.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
-                    "integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -5605,30 +6298,31 @@
             }
         },
         "eslint-plugin-prettier": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
-            "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+            "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
             "dev": true,
             "requires": {
                 "prettier-linter-helpers": "^1.0.0"
             }
         },
         "eslint-scope": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-            "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+            "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+            "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^1.0.0"
+                "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
@@ -5638,19 +6332,20 @@
             "dev": true
         },
         "espree": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+            "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "^7.1.0",
+                "acorn-jsx": "^5.1.0",
+                "eslint-visitor-keys": "^1.1.0"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+                    "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
                     "dev": true
                 }
             }
@@ -5695,9 +6390,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+            "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
             "dev": true
         },
         "events": {
@@ -5906,6 +6601,23 @@
                 }
             }
         },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
+            }
+        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6103,9 +6815,9 @@
             "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
         },
         "figures": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+            "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
@@ -6131,9 +6843,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
-                    "integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -6229,9 +6941,9 @@
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
                     "dev": true
                 }
             }
@@ -6406,8 +7118,7 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -6425,13 +7136,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -6444,18 +7153,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -6558,8 +7264,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -6569,7 +7274,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -6582,20 +7286,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -6612,7 +7313,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -6685,8 +7385,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -6696,7 +7395,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -6772,8 +7470,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -6803,7 +7500,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6821,7 +7517,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -6860,13 +7555,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 }
             }
         },
@@ -6957,27 +7650,12 @@
             }
         },
         "glob-parent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+            "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+            "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-                },
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "requires": {
-                        "is-extglob": "^2.1.0"
-                    }
-                }
+                "is-glob": "^4.0.1"
             }
         },
         "global-modules": {
@@ -7135,14 +7813,6 @@
             "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                }
             }
         },
         "has-binary2": {
@@ -7266,9 +7936,9 @@
             }
         },
         "hosted-git-info": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-            "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+            "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -7452,12 +8122,12 @@
             "dev": true
         },
         "http-proxy": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
             "dev": true,
             "requires": {
-                "eventemitter3": "^3.0.0",
+                "eventemitter3": "^4.0.0",
                 "follow-redirects": "^1.0.0",
                 "requires-port": "^1.0.0"
             }
@@ -7571,12 +8241,6 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
-        "indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true
-        },
         "indexes-of": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -7615,9 +8279,9 @@
             "dev": true
         },
         "inquirer": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-            "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+            "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
             "dev": true,
             "requires": {
                 "ansi-escapes": "^4.2.1",
@@ -7629,35 +8293,26 @@
                 "lodash": "^4.17.15",
                 "mute-stream": "0.0.8",
                 "run-async": "^2.2.0",
-                "rxjs": "^6.4.0",
+                "rxjs": "^6.5.3",
                 "string-width": "^4.1.0",
                 "strip-ansi": "^5.1.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-escapes": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-                    "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+                    "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
                     "dev": true,
                     "requires": {
-                        "type-fest": "^0.5.2"
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
-                },
-                "cli-cursor": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-                    "dev": true,
-                    "requires": {
-                        "restore-cursor": "^3.1.0"
-                    }
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
@@ -7665,61 +8320,32 @@
                     "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
                     "dev": true
                 },
-                "figures": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-                    "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "^1.0.5"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
-                "mute-stream": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-                    "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-                    "dev": true,
-                    "requires": {
-                        "mimic-fn": "^2.1.0"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-                    "dev": true,
-                    "requires": {
-                        "onetime": "^5.1.0",
-                        "signal-exit": "^3.0.2"
-                    }
-                },
                 "string-width": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-                    "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
                     "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^5.2.0"
+                        "strip-ansi": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
                     }
                 },
                 "strip-ansi": {
@@ -7729,6 +8355,14 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "dev": true
+                        }
                     }
                 }
             }
@@ -7827,9 +8461,9 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-callable": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
         },
         "is-ci": {
             "version": "1.2.1",
@@ -8057,11 +8691,18 @@
             }
         },
         "is-symbol": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "^1.0.1"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+                }
             }
         },
         "is-typedarray": {
@@ -8170,14 +8811,6 @@
                 "babylon": "^6.18.0",
                 "istanbul-lib-coverage": "^1.2.1",
                 "semver": "^5.3.0"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-                    "dev": true
-                }
             }
         },
         "istanbul-lib-report": {
@@ -8263,32 +8896,6 @@
                 "jest-cli": "^24.9.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -8351,14 +8958,6 @@
                         "wrap-ansi": "^5.1.0"
                     }
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "is-ci": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -8389,13 +8988,6 @@
                         "@babel/types": "^7.4.0",
                         "istanbul-lib-coverage": "^2.0.5",
                         "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
                     }
                 },
                 "jest-cli": {
@@ -8542,14 +9134,6 @@
                         "yargs": "^13.3.0"
                     }
                 },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
                 "load-json-file": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -8560,11 +9144,6 @@
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "path-type": {
                     "version": "3.0.0",
@@ -8593,20 +9172,10 @@
                         "read-pkg": "^3.0.0"
                     }
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -8684,6 +9253,12 @@
                 "pretty-format": "^22.4.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "arr-diff": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -8863,6 +9438,12 @@
                 "pretty-format": "^22.4.3"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "jest-get-type": {
                     "version": "22.4.3",
                     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
@@ -9226,6 +9807,12 @@
                 "source-map-support": "^0.5.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "arr-diff": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -9402,6 +9989,12 @@
                 "xml": "^1.0.1"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "arr-diff": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -9964,6 +10557,15 @@
                     "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
                     "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
                     "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
                 }
             }
         },
@@ -9987,6 +10589,12 @@
                 "pretty-format": "^22.4.3"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "jest-get-type": {
                     "version": "22.4.3",
                     "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
@@ -10093,32 +10701,6 @@
                 "throat": "^4.0.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-                    "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.5.5",
-                        "@babel/generator": "^7.6.0",
-                        "@babel/helpers": "^7.6.0",
-                        "@babel/parser": "^7.6.0",
-                        "@babel/template": "^7.6.0",
-                        "@babel/traverse": "^7.6.0",
-                        "@babel/types": "^7.6.0",
-                        "convert-source-map": "^1.1.0",
-                        "debug": "^4.1.0",
-                        "json5": "^2.1.0",
-                        "lodash": "^4.17.13",
-                        "resolve": "^1.3.2",
-                        "semver": "^5.4.1",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -10176,14 +10758,6 @@
                         "wrap-ansi": "^5.1.0"
                     }
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "is-generator-fn": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
@@ -10206,13 +10780,6 @@
                         "@babel/types": "^7.4.0",
                         "istanbul-lib-coverage": "^2.0.5",
                         "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
                     }
                 },
                 "jest-config": {
@@ -10356,14 +10923,6 @@
                         "supports-color": "^6.1.0"
                     }
                 },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
                 "load-json-file": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10379,11 +10938,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
                     "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "path-type": {
                     "version": "3.0.0",
@@ -10412,20 +10966,10 @@
                         "read-pkg": "^3.0.0"
                     }
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -10503,6 +11047,12 @@
                 "yargs": "^10.0.3"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "arr-diff": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -11051,9 +11601,9 @@
             "dev": true
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -11103,11 +11653,6 @@
                 "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-                },
                 "ws": {
                     "version": "5.2.2",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
@@ -11121,7 +11666,8 @@
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -11231,9 +11777,9 @@
             },
             "dependencies": {
                 "anymatch": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-                    "integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
                     "dev": true,
                     "requires": {
                         "normalize-path": "^3.0.0",
@@ -11256,25 +11802,25 @@
                     }
                 },
                 "chokidar": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-                    "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+                    "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^3.0.1",
-                        "braces": "^3.0.2",
-                        "fsevents": "^2.0.6",
-                        "glob-parent": "^5.0.0",
-                        "is-binary-path": "^2.1.0",
-                        "is-glob": "^4.0.1",
-                        "normalize-path": "^3.0.0",
-                        "readdirp": "^3.1.1"
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.1.2",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.3.0"
                     }
                 },
                 "core-js": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-                    "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
+                    "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==",
                     "dev": true
                 },
                 "fill-range": {
@@ -11287,20 +11833,11 @@
                     }
                 },
                 "fsevents": {
-                    "version": "2.0.7",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-                    "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+                    "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
                     "dev": true,
                     "optional": true
-                },
-                "glob-parent": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-                    "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
                 },
                 "is-binary-path": {
                     "version": "2.1.0",
@@ -11318,12 +11855,12 @@
                     "dev": true
                 },
                 "readdirp": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-                    "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+                    "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
                     "dev": true,
                     "requires": {
-                        "picomatch": "^2.0.4"
+                        "picomatch": "^2.0.7"
                     }
                 },
                 "to-regex-range": {
@@ -11592,12 +12129,6 @@
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
         },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -11660,62 +12191,10 @@
             }
         },
         "loglevel": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
-            "integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
+            "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
             "dev": true
-        },
-        "loglevel-colored-level-prefix": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
-            "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "loglevel": "^1.4.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "loglevelnext": {
             "version": "1.0.5",
@@ -11844,6 +12323,14 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                }
             }
         },
         "memory-fs": {
@@ -11955,9 +12442,9 @@
             }
         },
         "mimic-fn": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
         "mini-css-extract-plugin": {
@@ -12076,12 +12563,6 @@
                 "yargs-unparser": "1.5.0"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -12131,12 +12612,6 @@
                         "p-is-promise": "^2.0.0"
                     }
                 },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
                 "ms": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -12154,25 +12629,11 @@
                         "mem": "^4.0.0"
                     }
                 },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "6.0.0",
@@ -12249,9 +12710,9 @@
             "dev": true
         },
         "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "nan": {
@@ -12357,9 +12818,9 @@
             }
         },
         "node-forge": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
-            "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
             "dev": true
         },
         "node-int64": {
@@ -12428,11 +12889,18 @@
             "dev": true
         },
         "node-releases": {
-            "version": "1.1.30",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.30.tgz",
-            "integrity": "sha512-BHcr1g6NeUH12IL+X3Flvs4IOnl1TL0JczUhEZjDE+FXXPQcVCNr8NEPb01zqGxzhTpdyJL5GXemaCW7aw6Khw==",
+            "version": "1.1.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
+            "integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
             "requires": {
-                "semver": "^5.3.0"
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
             }
         },
         "normalize-package-data": {
@@ -12490,9 +12958,9 @@
             "dev": true
         },
         "nwsapi": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-            "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -12570,14 +13038,14 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
         },
         "object-is": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+            "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
             "dev": true
         },
         "object-keys": {
@@ -12633,15 +13101,51 @@
             }
         },
         "object.values": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-            "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+            "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.12.0",
+                "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+                    "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.1.5",
+                        "is-regex": "^1.0.5",
+                        "object-inspect": "^1.7.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.0",
+                        "string.prototype.trimleft": "^2.1.1",
+                        "string.prototype.trimright": "^2.1.1"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+                    "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                }
             }
         },
         "obuf": {
@@ -12674,12 +13178,12 @@
             }
         },
         "onetime": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "^2.1.0"
             }
         },
         "opn": {
@@ -12708,23 +13212,16 @@
             }
         },
         "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
             "requires": {
                 "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
+                "fast-levenshtein": "~2.0.6",
                 "levn": "~0.3.0",
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-                }
+                "word-wrap": "~1.2.3"
             }
         },
         "original": {
@@ -12897,9 +13394,9 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-            "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
             "requires": {
                 "asn1.js": "^4.0.0",
                 "browserify-aes": "^1.0.0",
@@ -13060,9 +13557,9 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-            "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+            "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
             "dev": true
         },
         "pify": {
@@ -13107,20 +13604,29 @@
             "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
         },
         "portfinder": {
-            "version": "1.0.24",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz",
-            "integrity": "sha512-ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==",
+            "version": "1.0.25",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+            "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
             "dev": true,
             "requires": {
-                "async": "^1.5.2",
-                "debug": "^2.2.0",
-                "mkdirp": "0.5.x"
+                "async": "^2.6.2",
+                "debug": "^3.1.1",
+                "mkdirp": "^0.5.1"
             },
             "dependencies": {
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
@@ -13436,9 +13942,9 @@
             }
         },
         "postcss-modules-scope": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
-            "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
+            "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
             "dev": true,
             "requires": {
                 "postcss": "^7.0.6",
@@ -13734,345 +14240,6 @@
             "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
             "dev": true
         },
-        "prettier-eslint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.0.tgz",
-            "integrity": "sha512-0dael2aMpMAxAwClnLi2Coc30v3BubsTX6clqseZ8NFCJZnbZlwxZGHHESYBlqTyN9lvZDHHv+XdeHW0fKhxJQ==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/parser": "^1.10.2",
-                "common-tags": "^1.4.0",
-                "core-js": "^3.1.4",
-                "dlv": "^1.1.0",
-                "eslint": "^5.0.0",
-                "indent-string": "^4.0.0",
-                "lodash.merge": "^4.6.0",
-                "loglevel-colored-level-prefix": "^1.0.0",
-                "prettier": "^1.7.0",
-                "pretty-format": "^23.0.1",
-                "require-relative": "^0.8.7",
-                "typescript": "^3.2.1",
-                "vue-eslint-parser": "^2.0.2"
-            },
-            "dependencies": {
-                "@typescript-eslint/experimental-utils": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-                    "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/json-schema": "^7.0.3",
-                        "@typescript-eslint/typescript-estree": "1.13.0",
-                        "eslint-scope": "^4.0.0"
-                    }
-                },
-                "@typescript-eslint/parser": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-                    "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/eslint-visitor-keys": "^1.0.0",
-                        "@typescript-eslint/experimental-utils": "1.13.0",
-                        "@typescript-eslint/typescript-estree": "1.13.0",
-                        "eslint-visitor-keys": "^1.0.0"
-                    }
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-                    "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-                    "dev": true,
-                    "requires": {
-                        "lodash.unescape": "4.0.1",
-                        "semver": "5.5.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "5.5.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-                            "dev": true
-                        }
-                    }
-                },
-                "acorn-jsx": {
-                    "version": "5.0.2",
-                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-                    "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
-                    "dev": true
-                },
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "chardet": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-                    "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-                    "dev": true
-                },
-                "core-js": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-                    "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "doctrine": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-                    "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2"
-                    }
-                },
-                "eslint": {
-                    "version": "5.16.0",
-                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-                    "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "ajv": "^6.9.1",
-                        "chalk": "^2.1.0",
-                        "cross-spawn": "^6.0.5",
-                        "debug": "^4.0.1",
-                        "doctrine": "^3.0.0",
-                        "eslint-scope": "^4.0.3",
-                        "eslint-utils": "^1.3.1",
-                        "eslint-visitor-keys": "^1.0.0",
-                        "espree": "^5.0.1",
-                        "esquery": "^1.0.1",
-                        "esutils": "^2.0.2",
-                        "file-entry-cache": "^5.0.1",
-                        "functional-red-black-tree": "^1.0.1",
-                        "glob": "^7.1.2",
-                        "globals": "^11.7.0",
-                        "ignore": "^4.0.6",
-                        "import-fresh": "^3.0.0",
-                        "imurmurhash": "^0.1.4",
-                        "inquirer": "^6.2.2",
-                        "js-yaml": "^3.13.0",
-                        "json-stable-stringify-without-jsonify": "^1.0.1",
-                        "levn": "^0.3.0",
-                        "lodash": "^4.17.11",
-                        "minimatch": "^3.0.4",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "optionator": "^0.8.2",
-                        "path-is-inside": "^1.0.2",
-                        "progress": "^2.0.0",
-                        "regexpp": "^2.0.1",
-                        "semver": "^5.5.1",
-                        "strip-ansi": "^4.0.0",
-                        "strip-json-comments": "^2.0.1",
-                        "table": "^5.2.3",
-                        "text-table": "^0.2.0"
-                    }
-                },
-                "espree": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-                    "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "^6.0.7",
-                        "acorn-jsx": "^5.0.0",
-                        "eslint-visitor-keys": "^1.0.0"
-                    }
-                },
-                "external-editor": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-                    "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-                    "dev": true,
-                    "requires": {
-                        "chardet": "^0.7.0",
-                        "iconv-lite": "^0.4.24",
-                        "tmp": "^0.0.33"
-                    }
-                },
-                "file-entry-cache": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-                    "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-                    "dev": true,
-                    "requires": {
-                        "flat-cache": "^2.0.1"
-                    }
-                },
-                "flat-cache": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-                    "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-                    "dev": true,
-                    "requires": {
-                        "flatted": "^2.0.0",
-                        "rimraf": "2.6.3",
-                        "write": "1.0.3"
-                    }
-                },
-                "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-                    "dev": true
-                },
-                "import-fresh": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-                    "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-                    "dev": true,
-                    "requires": {
-                        "parent-module": "^1.0.0",
-                        "resolve-from": "^4.0.0"
-                    }
-                },
-                "inquirer": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-                    "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-escapes": "^3.2.0",
-                        "chalk": "^2.4.2",
-                        "cli-cursor": "^2.1.0",
-                        "cli-width": "^2.0.0",
-                        "external-editor": "^3.0.3",
-                        "figures": "^2.0.0",
-                        "lodash": "^4.17.12",
-                        "mute-stream": "0.0.7",
-                        "run-async": "^2.2.0",
-                        "rxjs": "^6.4.0",
-                        "string-width": "^2.1.0",
-                        "strip-ansi": "^5.1.0",
-                        "through": "^2.3.6"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "5.2.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^4.1.0"
-                            }
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "23.6.0",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-                    "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0",
-                        "ansi-styles": "^3.2.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                            "dev": true
-                        }
-                    }
-                },
-                "regexpp": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-                    "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-                    "dev": true
-                },
-                "resolve-from": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-                    "dev": true
-                },
-                "rimraf": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "slice-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-                    "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "astral-regex": "^1.0.0",
-                        "is-fullwidth-code-point": "^2.0.0"
-                    }
-                },
-                "table": {
-                    "version": "5.4.6",
-                    "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-                    "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.10.2",
-                        "lodash": "^4.17.14",
-                        "slice-ansi": "^2.1.0",
-                        "string-width": "^3.0.0"
-                    },
-                    "dependencies": {
-                        "string-width": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                            "dev": true,
-                            "requires": {
-                                "emoji-regex": "^7.0.1",
-                                "is-fullwidth-code-point": "^2.0.0",
-                                "strip-ansi": "^5.1.0"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "5.2.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^4.1.0"
-                            }
-                        }
-                    }
-                },
-                "write": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-                    "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-                    "dev": true,
-                    "requires": {
-                        "mkdirp": "^0.5.1"
-                    }
-                }
-            }
-        },
         "prettier-linter-helpers": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -14147,9 +14314,9 @@
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
         "prompts": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
-            "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
+            "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
             "requires": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.3"
@@ -14177,9 +14344,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-            "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+            "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -14324,9 +14491,9 @@
             }
         },
         "react-is": {
-            "version": "16.9.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-            "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
         },
         "read-pkg": {
             "version": "1.1.0",
@@ -14485,12 +14652,49 @@
             }
         },
         "regexp.prototype.flags": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-            "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+            "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+                    "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.1.5",
+                        "is-regex": "^1.0.5",
+                        "object-inspect": "^1.7.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.0",
+                        "string.prototype.trimleft": "^2.1.1",
+                        "string.prototype.trimright": "^2.1.1"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+                    "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                }
             }
         },
         "regexpp": {
@@ -14520,9 +14724,9 @@
             "dev": true
         },
         "regjsparser": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-            "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+            "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -14556,21 +14760,6 @@
                 "htmlparser2": "^3.3.0",
                 "strip-ansi": "^3.0.0",
                 "utila": "^0.4.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
             }
         },
         "repeat-element": {
@@ -14641,19 +14830,19 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.15"
             }
         },
         "request-promise-native": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
             "requires": {
-                "request-promise-core": "1.1.2",
+                "request-promise-core": "1.1.3",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             }
@@ -14667,12 +14856,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-        },
-        "require-relative": {
-            "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-            "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-            "dev": true
         },
         "requires-port": {
             "version": "1.0.0",
@@ -14735,12 +14918,12 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "restore-cursor": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
+                "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
             }
         },
@@ -14865,9 +15048,9 @@
                     }
                 },
                 "exec-sh": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
-                    "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg=="
+                    "version": "0.3.4",
+                    "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+                    "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A=="
                 }
             }
         },
@@ -14898,12 +15081,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.6",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.6.tgz",
-            "integrity": "sha512-i3+CeqxL7DpAazgVpAGdKMwHuL63B5nhJMh9NQ7xmChGkA3jNFflq6Jyo1LLJYcr3idWiNOPWHCrm4zMayLG4w==",
+            "version": "1.10.7",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
             "dev": true,
             "requires": {
-                "node-forge": "0.8.2"
+                "node-forge": "0.9.0"
             }
         },
         "semver": {
@@ -15095,9 +15278,9 @@
             }
         },
         "sisteransi": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-            "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg=="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
+            "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
         },
         "slash": {
             "version": "2.0.0",
@@ -15250,9 +15433,9 @@
             }
         },
         "socket.io-adapter": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-            "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+            "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
             "dev": true
         },
         "socket.io-client": {
@@ -15327,9 +15510,9 @@
             }
         },
         "sockjs-client": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
-            "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+            "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
             "dev": true,
             "requires": {
                 "debug": "^3.2.5",
@@ -15691,9 +15874,9 @@
             }
         },
         "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
         },
         "streamroller": {
             "version": "1.0.6",
@@ -15732,31 +15915,61 @@
             "requires": {
                 "astral-regex": "^1.0.0",
                 "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
             "requires": {
+                "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "strip-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "string.prototype.trimleft": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
             "requires": {
                 "define-properties": "^1.1.3",
                 "function-bind": "^1.1.1"
             }
         },
         "string.prototype.trimright": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
             "requires": {
                 "define-properties": "^1.1.3",
                 "function-bind": "^1.1.1"
@@ -15771,11 +15984,11 @@
             }
         },
         "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -15789,9 +16002,9 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
             "dev": true
         },
         "style-loader": {
@@ -15849,17 +16062,17 @@
             }
         },
         "svgo": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-            "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+            "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
                 "coa": "^2.0.2",
                 "css-select": "^2.0.0",
                 "css-select-base-adapter": "^0.1.1",
-                "css-tree": "1.0.0-alpha.33",
-                "csso": "^3.5.1",
+                "css-tree": "1.0.0-alpha.37",
+                "csso": "^4.0.2",
                 "js-yaml": "^3.13.1",
                 "mkdirp": "~0.5.1",
                 "object.values": "^1.1.0",
@@ -15870,16 +16083,22 @@
             },
             "dependencies": {
                 "css-select": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-                    "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+                    "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
                     "dev": true,
                     "requires": {
                         "boolbase": "^1.0.0",
-                        "css-what": "^2.1.2",
+                        "css-what": "^3.2.1",
                         "domutils": "^1.7.0",
                         "nth-check": "^1.0.2"
                     }
+                },
+                "css-what": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+                    "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
+                    "dev": true
                 }
             }
         },
@@ -15898,34 +16117,6 @@
                 "lodash": "^4.17.14",
                 "slice-ansi": "^2.1.0",
                 "string-width": "^3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                }
             }
         },
         "tapable": {
@@ -15934,9 +16125,9 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "terser": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz",
-            "integrity": "sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
+            "integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
             "requires": {
                 "commander": "^2.20.0",
                 "source-map": "~0.6.1",
@@ -15944,19 +16135,26 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-            "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.7.0",
+                "serialize-javascript": "^2.1.2",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
                 "worker-farm": "^1.7.0"
+            },
+            "dependencies": {
+                "serialize-javascript": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+                    "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+                }
             }
         },
         "test-exclude": {
@@ -16081,9 +16279,9 @@
             }
         },
         "thunky": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
-            "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true
         },
         "timers-browserify": {
@@ -16128,7 +16326,8 @@
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",
@@ -16234,9 +16433,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-            "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
             "dev": true
         },
         "type-check": {
@@ -16254,9 +16453,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-            "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
         "type-is": {
@@ -16275,17 +16474,17 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-            "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+            "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
             "requires": {
-                "commander": "~2.20.0",
+                "commander": "~2.20.3",
                 "source-map": "~0.6.1"
             }
         },
@@ -16553,9 +16752,9 @@
             "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
         },
         "v8-compile-cache": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-            "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+            "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
             "dev": true
         },
         "validate-npm-package-license": {
@@ -16590,56 +16789,15 @@
             }
         },
         "vm-browserify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-            "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
         },
         "void-elements": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
             "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
             "dev": true
-        },
-        "vue-eslint-parser": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
-            "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
-            "dev": true,
-            "requires": {
-                "debug": "^3.1.0",
-                "eslint-scope": "^3.7.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.2",
-                "esquery": "^1.0.0",
-                "lodash": "^4.17.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "eslint-scope": {
-                    "version": "3.7.3",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-                    "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
-            }
         },
         "w3c-hr-time": {
             "version": "1.0.1",
@@ -16692,9 +16850,9 @@
             "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
         },
         "webpack": {
-            "version": "4.39.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
-            "integrity": "sha512-BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==",
+            "version": "4.41.4",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.4.tgz",
+            "integrity": "sha512-Lc+2uB6NjpCWsHI3trkoISOI64h9QYIXenbEWj3bn3oyjfB1lEBXjWAfAyY2sM0rZn41oD5V91OLwKRwS6Wp8Q==",
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
                 "@webassemblyjs/helper-module-context": "1.8.5",
@@ -16716,15 +16874,31 @@
                 "node-libs-browser": "^2.2.1",
                 "schema-utils": "^1.0.0",
                 "tapable": "^1.1.3",
-                "terser-webpack-plugin": "^1.4.1",
+                "terser-webpack-plugin": "^1.4.3",
                 "watchpack": "^1.6.0",
                 "webpack-sources": "^1.4.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+                    "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+                },
+                "eslint-scope": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+                    "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                }
             }
         },
         "webpack-cli": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.8.tgz",
-            "integrity": "sha512-RANYSXwikSWINjHMd/mtesblNSpjpDLoYTBtP99n1RhXqVI/wxN40Auqy42I7y4xrbmRBoA5Zy5E0JSBD5XRhw==",
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz",
+            "integrity": "sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==",
             "dev": true,
             "requires": {
                 "chalk": "2.4.2",
@@ -16783,12 +16957,6 @@
                         "p-is-promise": "^2.0.0"
                     }
                 },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
                 "os-locale": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -16800,17 +16968,6 @@
                         "mem": "^4.0.0"
                     }
                 },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -16819,6 +16976,12 @@
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
+                },
+                "v8-compile-cache": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+                    "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+                    "dev": true
                 },
                 "wrap-ansi": {
                     "version": "5.1.0",
@@ -16853,9 +17016,9 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
-            "integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+            "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
             "dev": true,
             "requires": {
                 "memory-fs": "^0.4.1",
@@ -16878,14 +17041,14 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
-            "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.1.tgz",
+            "integrity": "sha512-9F5DnfFA9bsrhpUCAfQic/AXBVHvq+3gQS+x6Zj0yc1fVVE0erKh2MV4IV12TBewuTrYeeTIRwCH9qLMvdNvTw==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
                 "bonjour": "^3.5.0",
-                "chokidar": "^2.1.6",
+                "chokidar": "^2.1.8",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
                 "debug": "^4.1.1",
@@ -16896,32 +17059,32 @@
                 "import-local": "^2.0.0",
                 "internal-ip": "^4.3.0",
                 "ip": "^1.1.5",
-                "is-absolute-url": "^3.0.0",
+                "is-absolute-url": "^3.0.2",
                 "killable": "^1.0.1",
-                "loglevel": "^1.6.3",
+                "loglevel": "^1.6.4",
                 "opn": "^5.5.0",
                 "p-retry": "^3.0.1",
-                "portfinder": "^1.0.21",
+                "portfinder": "^1.0.24",
                 "schema-utils": "^1.0.0",
-                "selfsigned": "^1.10.4",
+                "selfsigned": "^1.10.6",
                 "semver": "^6.3.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "0.3.19",
-                "sockjs-client": "1.3.0",
+                "sockjs-client": "1.4.0",
                 "spdy": "^4.0.1",
                 "strip-ansi": "^3.0.1",
                 "supports-color": "^6.1.0",
                 "url": "^0.11.0",
-                "webpack-dev-middleware": "^3.7.0",
+                "webpack-dev-middleware": "^3.7.1",
                 "webpack-log": "^2.0.0",
                 "ws": "^6.2.1",
                 "yargs": "12.0.5"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
                 "debug": {
@@ -16946,9 +17109,9 @@
                     "dev": true
                 },
                 "is-absolute-url": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
-                    "integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+                    "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
                     "dev": true
                 },
                 "lcid": {
@@ -16970,12 +17133,6 @@
                         "mimic-fn": "^2.0.0",
                         "p-is-promise": "^2.0.0"
                     }
-                },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -17006,13 +17163,25 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
                     }
                 },
                 "webpack-log": {
@@ -17181,7 +17350,39 @@
             "dev": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "wordwrap": {
             "version": "0.0.3",
@@ -17206,12 +17407,6 @@
                 "strip-ansi": "^3.0.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -17230,15 +17425,6 @@
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
                         "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -17345,9 +17531,9 @@
             "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "yargs": {
             "version": "10.1.2",
@@ -17369,6 +17555,12 @@
                 "yargs-parser": "^8.1.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -17430,6 +17622,25 @@
                     "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
                 "y18n": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -17467,6 +17678,12 @@
                 "yargs": "^12.0.5"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "get-caller-file": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -17499,12 +17716,6 @@
                         "p-is-promise": "^2.0.0"
                     }
                 },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
                 "os-locale": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -17521,6 +17732,25 @@
                     "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
                     "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
                 },
                 "yargs": {
                     "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
         "lodash": "^4.17.15",
         "postcss-flexbugs-fixes": "^4.1.0",
         "simplebar": "^3.1.1",
-        "uglifyjs-webpack-plugin": "^2.1.2",
-        "webpack": "^4.28.3",
+        "uglifyjs-webpack-plugin": "^2.2.0",
+        "webpack": "^4.41.4",
         "xss-filters": "^1.2.7"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8799,6 +8799,11 @@ serialize-javascript@^1.7.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -9459,16 +9464,16 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-terser-webpack-plugin@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz#61b18e40eaee5be97e771cdbb10ed1280888c2b4"
-  integrity sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
+terser-webpack-plugin@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
+  integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
   dependencies:
     cacache "^12.0.2"
     find-cache-dir "^2.1.0"
     is-wsl "^1.1.0"
     schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
+    serialize-javascript "^2.1.2"
     source-map "^0.6.1"
     terser "^4.1.2"
     webpack-sources "^1.4.0"
@@ -9729,7 +9734,7 @@ uglify-js@^3.1.4, uglify-js@^3.6.0:
     commander "~2.20.0"
     source-map "~0.6.1"
 
-uglifyjs-webpack-plugin@^2.1.2:
+uglifyjs-webpack-plugin@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
   integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
@@ -10137,10 +10142,10 @@ webpack-strip-block@^0.2.0:
   dependencies:
     loader-utils "^1.1.0"
 
-webpack@^4.28.3:
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.40.2.tgz#d21433d250f900bf0facbabe8f50d585b2dc30a7"
-  integrity sha512-5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==
+webpack@^4.41.4:
+  version "4.41.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.4.tgz#4bec4125224bdf50efa8be6226c19047599cd034"
+  integrity sha512-Lc+2uB6NjpCWsHI3trkoISOI64h9QYIXenbEWj3bn3oyjfB1lEBXjWAfAyY2sM0rZn41oD5V91OLwKRwS6Wp8Q==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"
@@ -10162,7 +10167,7 @@ webpack@^4.28.3:
     node-libs-browser "^2.2.1"
     schema-utils "^1.0.0"
     tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.1"
+    terser-webpack-plugin "^1.4.3"
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 


### PR DESCRIPTION

<img width="505" alt="스크린샷 2019-12-25 오전 10 48 57" src="https://user-images.githubusercontent.com/40051225/71428626-3d995480-2705-11ea-96b5-d39b17d1ce08.png">

Security alert: https://github.com/entrylabs/entryjs/network/alert/yarn.lock/serialize-javascript/open

- uglifyjs 는 버전에 문제가 없을 수 있으나 일단 사용처이기 때문에 업그레이드
- 실제로 2.1.1 버전을 사용하는 라이브러리는 webpack#terser-webpack-plugin -> 2.1.2 로 올림