### PR TITLE
[issue/11302] 값블록을 바로 드래그 -> 제거하면 값블록뷰가 중첩되던 문제 수정

### DIFF
--- a/src/playground/field/block.js
+++ b/src/playground/field/block.js
@@ -370,7 +370,7 @@ Entry.FieldBlock = class FieldBlock extends Entry.Field {
     }
 
     spliceBlock() {
-        this.updateValueBlock();
+        // this.updateValueBlock();
     }
 
     _updateBG() {

--- a/src/playground/field/block.js
+++ b/src/playground/field/block.js
@@ -369,10 +369,6 @@ Entry.FieldBlock = class FieldBlock extends Entry.Field {
         return block;
     }
 
-    spliceBlock() {
-        // this.updateValueBlock();
-    }
-
     _updateBG() {
         if (this.magneting) {
             this._bg = this.svgGroup.elem('path', {


### PR DESCRIPTION
문제의 출발은 commands/block.js#destrodyBlockBelow 커맨드에서 부터입니다.

재현조건은 아래와 같습니다.
- 값블록을 드래그해서 바로 삭제 (destroyBlockBelow)
- 값블록을 블록조립소로 빼는 것은 상관이 없습니다. (separateBlock)

로직 플로우는 아래와 같습니다.
- 커맨드발생
- block#doDestroyBelow#destory
- block.js#L440 (in destroy function)

문제는 아래와 같습니다.
- 해당 라인의 로직이 _setValueBlock 을 호출하는데, 이때 새 값블록뷰가 만들어짐
- 이때, 기존의 값블록뷰가 삭제되는 로직이 없음 (덮어씌워짐)
- 이 상태에서 다른 값블록을 합치기 하면,  마지막에 만들어진 블록뷰는 정상적으로 지워지나 연결이 끊어져 뷰만 남은 값블록이 아직 남아있는 상태가됨

참고사항은 아래와 같습니다.
- spliceBlock 이 뭘 의미하는지 알수없으며, 왜 블록 클래스에도 존재하는지 알수없음 (변수명으로 보면 의도한 로직은 아닌 것 같음)
- block#destory 에서만 불리는 함수
- 근데 없어도 잘돌아가는데.. 어떤 영향을 줄지 모르겠음. 또한 FieldOutput 에도 이 로직이 있음. 이쪽도 문제가 발생할 여지가 있음

주석만으로 처리한 이유는 아래와 같습니다.
- spliceBlock 에 대한 처리가 실제로 유효한지 잘 모르겠습니다.
- 이 함수 자체가 삭제되는데 있어 다른 로직들에 방어로직을 전부 넣고, 로직을 정리해야하는지 알수가 없습니다.
- 만약 정리되어야 한다면, spliceBlock 이 사용되는 위치를 전부 정리하고, thread 에만 남겨야 할 것 같습니다.
  - 원래 로직의 변수명을 보면 thread 가 들어왔을 것이라는 것을 상정하고 만든 것으로 보입니다.