### PR TITLE
Issue/11333 특정작품 부스트 모드 실행불가 관련 수정 

### DIFF
--- a/src/class/pixi/atlas/PIXIAtlasHelper.ts
+++ b/src/class/pixi/atlas/PIXIAtlasHelper.ts
@@ -4,17 +4,20 @@ import { ImageRect } from '../../maxrect-packer/geom/ImageRect';
 import { autoFit } from '../utils/AutoFit';
 
 interface ISimpleRect {
-    x:number; y:number; width:number, height:number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
 }
 
-declare let _:any;
+declare let _: any;
 
 class _PIXIAtlasHelper {
     /**
      * rawData.fileurl || rawData.filename
      * @param rawData
      */
-    getRawPath(rawData:IRawPicture):string {
+    getRawPath(rawData: IRawPicture): string {
         return rawData.fileurl || rawData.filename;
     }
 
@@ -22,31 +25,40 @@ class _PIXIAtlasHelper {
      * EntryObject를 전부 조회하여 지정된 장면에서 사용하는 picture의 경로 set 객체를 리턴.
      * @param sceneID
      */
-    getScenePathSet(sceneID:string):PrimitiveSet {
-        var arrObj:any[] = Entry.container.getAllObjects();
-        var pathSet = new PrimitiveSet();
+    getScenePathSet(sceneID: string): PrimitiveSet {
+        const arrObj: any[] = Entry.container.getAllObjects();
+        const pathSet = new PrimitiveSet();
 
-        var LEN = arrObj.length;
-        var LEN2;
-        var pics:IRawPicture[];
-        var obj:any;
-        for (var i = 0; i < LEN; i++) {
+        const LEN = arrObj.length;
+        let LEN2;
+        let pics: IRawPicture[];
+        let obj: any;
+        for (let i = 0; i < LEN; i++) {
             obj = arrObj[i];
-            if( sceneID != obj.scene.id ) continue;
+            if (sceneID != obj.scene.id) {
+                continue;
+            }
             pics = obj.pictures;
-            if (!pics || !(LEN2 = pics.length)) continue;
-            for (var j = 0; j < LEN2; j++) {
+            if (!pics || !(LEN2 = pics.length)) {
+                continue;
+            }
+            for (let j = 0; j < LEN2; j++) {
                 pathSet.put(this.getRawPath(pics[j]));
             }
         }
         return pathSet;
     }
 
-    getNewImageRect(pic:IRawPicture, texMaxRect:ISimpleRect):ImageRect {
-        let w = pic.dimension.width,
-            h = pic.dimension.height;
-        let r = new ImageRect(0,0, w, h);
-        if(w > texMaxRect.width || h > texMaxRect.height ) {
+    /**
+     * 이미지별 텍스쳐 사이즈 리턴 (정수)
+     * @param pic, texMaxRect
+     */
+    getNewImageRect(pic: IRawPicture, texMaxRect: ISimpleRect): ImageRect {
+        const w = pic.dimension.width | 0;
+        const h = pic.dimension.height | 0;
+
+        const r = new ImageRect(0, 0, w, h);
+        if (w > texMaxRect.width || h > texMaxRect.height) {
             autoFit.fit(texMaxRect, r, autoFit.ScaleMode.INSIDE, autoFit.AlignMode.TL);
             r.width = Math.ceil(r.width);
             r.height = Math.ceil(r.height);
@@ -56,9 +68,6 @@ class _PIXIAtlasHelper {
         }
         return r;
     }
-
-
 }
 
-
-export let PIXIAtlasHelper:_PIXIAtlasHelper = new _PIXIAtlasHelper();
+export const PIXIAtlasHelper: _PIXIAtlasHelper = new _PIXIAtlasHelper();


### PR DESCRIPTION
https://oss.navercorp.com/entry/Entry/issues/11333
특정작품 부스트 모드 실행불가 관련 수정 

1. 저장된 작품 이미지 사이즈가 정수가 아닌 소수로 저장된 작품에서 발생. 
-  PIXIAtlasHelper.ts 이미지 사이즈 조회시 소수점을 정수로 처리되도록 방어코드 추가​
-  const w = pic.dimension.width | 0;
-  const h = pic.dimension.height | 0;

2. prettier 적용
