### PR TITLE
[issue/11416] Entry.Func 클래스화 및 clearProject 시 문제발생 이슈 수정

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,6 @@
         "prefer-spread": "warn",
         "arrow-spacing": "warn",
         "arrow-body-style": ["warn", "as-needed"],
-        "no-confusing-arrow": ["warn", { "allowParens": true }],
         "no-useless-constructor": "warn",
         "no-dupe-class-members": "warn",
         "no-duplicate-imports": "warn",

--- a/src/class/function.js
+++ b/src/class/function.js
@@ -1,567 +1,577 @@
-/*
- * @fileoverview Func object for entry function.
- */
-'use strict';
+class EntryFunc {
+    static isEdit = false;
+    static threads = {};
 
-/**
- * Block variable constructor
- * @param {variable model} variable
- * @constructor
- */
-Entry.Func = function(func) {
-    this.id = func && func.id ? func.id : Entry.generateHash();
-    let content;
-    //inspect empty content
-    if (func && func.content && func.content.length > 4) {
-        content = func.content;
-    }
-    this.content = content
-        ? new Entry.Code(content)
-        : new Entry.Code([
-              [
-                  {
-                      type: 'function_create',
-                      copyable: false,
-                      deletable: false,
-                      x: 40,
-                      y: 40,
-                  },
-              ],
-          ]);
-    this.block = null;
-    this.blockMenuBlock = null;
-    this._backupContent = null;
-    this.hashMap = {};
-
-    this.paramMap = {};
-
-    Entry.generateFunctionSchema(this.id);
-
-    if (func && func.content) {
-        const blockMap = this.content._blockMap;
-        for (const key in blockMap) {
-            Entry.Func.registerParamBlock(blockMap[key].type);
+    static registerFunction(func) {
+        const workspace = Entry && Entry.getMainWS();
+        if (!workspace) {
+            return;
         }
-        Entry.Func.generateWsBlock(this);
+        const blockMenu = workspace.getBlockMenu();
+        const menuCode = blockMenu.code;
+
+        this._targetFuncBlock = menuCode.createThread([
+            {
+                type: `func_${func.id}`,
+                category: 'func',
+                x: -9999,
+            },
+        ]);
+        func.blockMenuBlock = this._targetFuncBlock;
     }
 
-    Entry.Func.registerFunction(this);
-
-    Entry.Func.updateMenu();
-};
-
-Entry.Func.threads = {};
-
-Entry.Func.registerFunction = function(func) {
-    if (!Entry.playground) {
-        return;
+    static executeFunction(threadHash) {
+        let script = this.threads[threadHash];
+        script = Entry.Engine.computeThread(script.entity, script);
+        if (script) {
+            this.threads[threadHash] = script;
+            return true;
+        } else {
+            delete this.threads[threadHash];
+            return false;
+        }
     }
-    const workspace = Entry.playground.mainWorkspace;
-    if (!workspace) {
-        return;
+
+    static clearThreads() {
+        this.threads = {};
     }
-    const blockMenu = workspace.getBlockMenu();
-    const menuCode = blockMenu.code;
 
-    this._targetFuncBlock = menuCode.createThread([
-        {
-            type: `func_${func.id}`,
-            category: 'func',
-            x: -9999,
-        },
-    ]);
-    func.blockMenuBlock = this._targetFuncBlock;
-};
+    static edit(func) {
+        if (typeof func === 'string') {
+            func = Entry.variableContainer.getFunction(/(func_)?(.*)/.exec(func)[2]);
+        }
+        if (!func) {
+            console.error('no function');
+            return;
+        }
+        this.unbindFuncChangeEvent();
+        this.unbindWorkspaceStateChangeEvent();
 
-Entry.Func.executeFunction = function(threadHash) {
-    let script = this.threads[threadHash];
-    script = Entry.Engine.computeThread(script.entity, script);
-    if (script) {
-        this.threads[threadHash] = script;
+        this.cancelEdit();
+
+        this.targetFunc = func;
+        EntryFunc.isEdit = true;
+        Entry.getMainWS().blockMenu.deleteRendered('variable');
+        if (this.initEditView(func.content) === false) {
+            EntryFunc.isEdit = false;
+            return;
+        } // edit fail
+        this.bindFuncChangeEvent(func);
+        this.updateMenu();
+        setTimeout(() => {
+            const schema = Entry.block[`func_${func.id}`];
+            if (schema && schema.paramsBackupEvent) {
+                schema.paramsBackupEvent.notify();
+            }
+
+            this._backupContent = func.content.stringify();
+        }, 0);
+    }
+
+    static initEditView(content) {
+        if (!this.menuCode) {
+            this.setupMenuCode();
+        }
+        const workspace = Entry.getMainWS();
+        if (workspace.setMode(Entry.Workspace.MODE_OVERLAYBOARD) === false) {
+            this.endEdit('cancelEdit');
+            return false;
+        }
+        workspace.changeOverlayBoardCode(content);
+
+        this._workspaceStateEvent = workspace.changeEvent.attach(this, (message = 'cancelEdit') => {
+            this.endEdit(message);
+            if (workspace.getMode() === Entry.Workspace.MODE_VIMBOARD) {
+                workspace.blockMenu.banClass('functionInit');
+            }
+        });
+        content.board.alignThreads();
         return true;
-    } else {
-        delete this.threads[threadHash];
-        return false;
     }
-};
 
-Entry.Func.clearThreads = function() {
-    this.threads = {};
-};
+    static endEdit(message) {
+        this.unbindFuncChangeEvent();
+        this.unbindWorkspaceStateChangeEvent();
+        const targetFuncId = this.targetFunc.id;
 
-Entry.Func.prototype.destroy = function() {
-    this.blockMenuBlock && this.blockMenuBlock.destroy();
-};
-
-Entry.Func.edit = function(func) {
-    if (typeof func === 'string') {
-        func = Entry.variableContainer.getFunction(/(func_)?(.*)/.exec(func)[2]);
-    }
-    if (!func) {
-        console.error('no function');
-        return;
-    }
-    this.unbindFuncChangeEvent();
-    this.unbindWorkspaceStateChangeEvent();
-
-    this.cancelEdit();
-
-    this.targetFunc = func;
-    Entry.Func.isEdit = true;
-    Entry.getMainWS().blockMenu.deleteRendered('variable');
-    if (this.initEditView(func.content) === false) {
-        Entry.Func.isEdit = false;
-        return;
-    } // edit fail
-    this.bindFuncChangeEvent(func);
-    this.updateMenu();
-    setTimeout(() => {
-        const schema = Entry.block[`func_${func.id}`];
-        if (schema && schema.paramsBackupEvent) {
-            schema.paramsBackupEvent.notify();
+        if (this.targetFunc && this.targetFunc.content) {
+            this.targetFunc.content.destroyView();
         }
 
-        this._backupContent = func.content.stringify();
-    }, 0);
-};
-
-Entry.Func.initEditView = function(content) {
-    if (!this.menuCode) {
-        this.setupMenuCode();
-    }
-    const workspace = Entry.getMainWS();
-    if (workspace.setMode(Entry.Workspace.MODE_OVERLAYBOARD) === false) {
-        this.endEdit('cancelEdit');
-        return false;
-    }
-    workspace.changeOverlayBoardCode(content);
-
-    this._workspaceStateEvent = workspace.changeEvent.attach(this, (message = 'cancelEdit') => {
-        this.endEdit(message);
-        if (workspace.getMode() === Entry.Workspace.MODE_VIMBOARD) {
-            workspace.blockMenu.banClass('functionInit');
+        switch (message) {
+            case 'save':
+                this.save();
+                break;
+            case 'cancelEdit':
+                this.cancelEdit();
+                break;
         }
-    });
-    content.board.alignThreads();
-    return true;
-};
 
-Entry.Func.endEdit = function(message) {
-    this.unbindFuncChangeEvent();
-    this.unbindWorkspaceStateChangeEvent();
-    const targetFuncId = this.targetFunc.id;
+        this._backupContent = null;
 
-    if (this.targetFunc && this.targetFunc.content) {
-        this.targetFunc.content.destroyView();
-    }
-
-    switch (message) {
-        case 'save':
-            this.save();
-            break;
-        case 'cancelEdit':
-            this.cancelEdit();
-            break;
-    }
-
-    this._backupContent = null;
-
-    delete this.targetFunc;
-    Entry.Func.isEdit = false;
-    Entry.getMainWS().blockMenu.deleteRendered('variable');
-    const blockSchema = Entry.block[`func_${targetFuncId}`];
-    if (blockSchema && blockSchema.destroyParamsBackupEvent) {
-        blockSchema.destroyParamsBackupEvent.notify();
-    }
-    this.updateMenu();
-};
-
-Entry.Func.save = function() {
-    this.targetFunc.generateBlock(true);
-    Entry.variableContainer.saveFunction(this.targetFunc);
-
-    const ws = Entry.getMainWS();
-    if (ws && ws.overlayModefrom === Entry.Workspace.MODE_VIMBOARD) {
-        const mode = {};
-        mode.boardType = Entry.Workspace.MODE_VIMBOARD;
-        mode.textType = Entry.Vim.TEXT_TYPE_PY;
-        mode.runType = Entry.Vim.WORKSPACE_MODE;
-        Entry.getMainWS().setMode(mode);
-        Entry.variableContainer.functionAddButton_.addClass('disable');
-    }
-};
-
-Entry.Func.cancelEdit = function() {
-    if (!this.targetFunc) {
-        return;
-    }
-
-    if (!this.targetFunc.block) {
-        this._targetFuncBlock.destroy();
-        delete Entry.variableContainer.functions_[this.targetFunc.id];
-        delete Entry.variableContainer.selected;
-    } else {
-        if (this._backupContent) {
-            this.targetFunc.content.load(this._backupContent);
-            Entry.generateFunctionSchema(this.targetFunc.id);
-            Entry.Func.generateWsBlock(this.targetFunc, true);
+        delete this.targetFunc;
+        EntryFunc.isEdit = false;
+        Entry.getMainWS().blockMenu.deleteRendered('variable');
+        const blockSchema = Entry.block[`func_${targetFuncId}`];
+        if (blockSchema && blockSchema.destroyParamsBackupEvent) {
+            blockSchema.destroyParamsBackupEvent.notify();
         }
-    }
-    Entry.variableContainer.updateList();
-
-    const ws = Entry.getMainWS();
-    if (ws && ws.overlayModefrom === Entry.Workspace.MODE_VIMBOARD) {
-        const mode = {};
-        mode.boardType = Entry.Workspace.MODE_VIMBOARD;
-        mode.textType = Entry.Vim.TEXT_TYPE_PY;
-        mode.runType = Entry.Vim.WORKSPACE_MODE;
-        Entry.getMainWS().setMode(mode);
-        Entry.variableContainer.functionAddButton_.addClass('disable');
-    }
-};
-
-Entry.Func.setupMenuCode = function() {
-    const workspace = Entry.playground.mainWorkspace;
-    if (!workspace) {
-        return;
-    }
-    const blockMenu = workspace.getBlockMenu();
-    const menuCode = blockMenu.code;
-    const CATEGORY = 'func';
-    this._fieldLabel = menuCode
-        .createThread([
-            {
-                type: 'function_field_label',
-                copyable: false,
-                category: CATEGORY,
-                x: -9999,
-            },
-        ])
-        .getFirstBlock();
-
-    this._fieldString = menuCode
-        .createThread([
-            {
-                type: 'function_field_string',
-                category: CATEGORY,
-                x: -9999,
-                copyable: false,
-                params: [{ type: this.requestParamBlock('string') }],
-            },
-        ])
-        .getFirstBlock();
-
-    this._fieldBoolean = menuCode
-        .createThread([
-            {
-                type: 'function_field_boolean',
-                copyable: false,
-                category: CATEGORY,
-                x: -9999,
-                params: [{ type: this.requestParamBlock('boolean') }],
-            },
-        ])
-        .getFirstBlock();
-
-    this.menuCode = menuCode;
-    blockMenu.align();
-};
-
-Entry.Func.refreshMenuCode = function() {
-    if (!Entry.playground.mainWorkspace) {
-        return;
-    }
-    if (!this.menuCode) {
-        this.setupMenuCode();
+        this.updateMenu();
     }
 
-    this._fieldString.params[0].changeType(this.requestParamBlock('string'));
-    this._fieldBoolean.params[0].changeType(this.requestParamBlock('boolean'));
-};
+    static save() {
+        this.targetFunc.generateBlock(true);
+        Entry.variableContainer.saveFunction(this.targetFunc);
 
-Entry.Func.requestParamBlock = function(type) {
-    let blockPrototype;
-    switch (type) {
-        case 'string':
+        this._restoreBoardToVimBoard();
+    }
+
+    static cancelEdit() {
+        if (!this.targetFunc) {
+            return;
+        }
+
+        if (!this.targetFunc.block) {
+            this._targetFuncBlock.destroy();
+            delete Entry.variableContainer.functions_[this.targetFunc.id];
+            delete Entry.variableContainer.selected;
+        } else {
+            if (this._backupContent) {
+                this.targetFunc.content.load(this._backupContent);
+                this._generateFunctionSchema(this.targetFunc.id);
+                this.generateWsBlock(this.targetFunc, true);
+            }
+        }
+        Entry.variableContainer.updateList();
+
+        this._restoreBoardToVimBoard();
+    }
+
+    static setupMenuCode() {
+        const workspace = Entry.getMainWS();
+        if (!workspace) {
+            return;
+        }
+        const blockMenu = workspace.getBlockMenu();
+        const menuCode = blockMenu.code;
+        const CATEGORY = 'func';
+        this._fieldLabel = menuCode
+            .createThread([
+                {
+                    type: 'function_field_label',
+                    copyable: false,
+                    category: CATEGORY,
+                    x: -9999,
+                },
+            ])
+            .getFirstBlock();
+
+        this._fieldString = menuCode
+            .createThread([
+                {
+                    type: 'function_field_string',
+                    category: CATEGORY,
+                    x: -9999,
+                    copyable: false,
+                    params: [{ type: this.requestParamBlock('string') }],
+                },
+            ])
+            .getFirstBlock();
+
+        this._fieldBoolean = menuCode
+            .createThread([
+                {
+                    type: 'function_field_boolean',
+                    copyable: false,
+                    category: CATEGORY,
+                    x: -9999,
+                    params: [{ type: this.requestParamBlock('boolean') }],
+                },
+            ])
+            .getFirstBlock();
+
+        this.menuCode = menuCode; // TODO Destroy 혹은 cleanProject 같은 로직이 동작했을때 삭제 필요
+        blockMenu.align();
+    }
+
+    static refreshMenuCode() {
+        if (!Entry.playground.mainWorkspace) {
+            return;
+        }
+        if (!this.menuCode) {
+            this.setupMenuCode();
+        }
+
+        this._fieldString.params[0].changeType(this.requestParamBlock('string'));
+        this._fieldBoolean.params[0].changeType(this.requestParamBlock('boolean'));
+    }
+
+    static requestParamBlock(type) {
+        let blockPrototype;
+        switch (type) {
+            case 'string':
+                blockPrototype = Entry.block.function_param_string;
+                break;
+            case 'boolean':
+                blockPrototype = Entry.block.function_param_boolean;
+                break;
+            default:
+                return null;
+        }
+
+        const blockType = `${type}Param_${Entry.generateHash()}`;
+        Entry.block[blockType] = EntryFunc.createParamBlock(blockType, blockPrototype, type);
+        return blockType;
+    }
+
+    static registerParamBlock(type) {
+        if (!type) {
+            return;
+        }
+
+        let blockPrototype;
+        if (type.indexOf('stringParam') > -1) {
             blockPrototype = Entry.block.function_param_string;
-            break;
-        case 'boolean':
+        } else if (type.indexOf('booleanParam') > -1) {
             blockPrototype = Entry.block.function_param_boolean;
-            break;
-        default:
-            return null;
+        }
+
+        //not a function param block
+        if (!blockPrototype) {
+            return;
+        }
+
+        EntryFunc.createParamBlock(type, blockPrototype, type);
     }
 
-    const blockType = `${type}Param_${Entry.generateHash()}`;
-    Entry.block[blockType] = Entry.Func.createParamBlock(blockType, blockPrototype, type);
-    return blockType;
-};
+    static createParamBlock(type, blockPrototype, originalType) {
+        originalType = /string/gi.test(originalType)
+            ? 'function_param_string'
+            : 'function_param_boolean';
+        let blockSchema = function() {};
+        blockSchema.prototype = blockPrototype;
+        blockSchema = new blockSchema();
+        blockSchema.changeEvent = new Entry.Event();
+        blockSchema.template = Lang.template[originalType];
+        blockSchema.fontColor = blockPrototype.fontColor || '#FFF';
 
-Entry.Func.registerParamBlock = function(type) {
-    if (!type) {
-        return;
+        Entry.block[type] = blockSchema;
+        return blockSchema;
     }
 
-    let blockPrototype;
-    if (type.indexOf('stringParam') > -1) {
-        blockPrototype = Entry.block.function_param_string;
-    } else if (type.indexOf('booleanParam') > -1) {
-        blockPrototype = Entry.block.function_param_boolean;
-    }
-
-    //not a function param block
-    if (!blockPrototype) {
-        return;
-    }
-
-    Entry.Func.createParamBlock(type, blockPrototype, type);
-};
-
-Entry.Func.createParamBlock = function(type, blockPrototype, originalType) {
-    originalType = /string/gi.test(originalType)
-        ? 'function_param_string'
-        : 'function_param_boolean';
-    let blockSchema = function() {};
-    blockSchema.prototype = blockPrototype;
-    blockSchema = new blockSchema();
-    blockSchema.changeEvent = new Entry.Event();
-    blockSchema.template = Lang.template[originalType];
-    blockSchema.fontColor = blockPrototype.fontColor || '#FFF';
-
-    Entry.block[type] = blockSchema;
-    return blockSchema;
-};
-
-Entry.Func.updateMenu = function() {
-    const workspace = Entry.getMainWS();
-    if (!workspace) {
-        return;
-    }
-    const blockMenu = workspace.getBlockMenu();
-    if (this.targetFunc) {
-        !this.menuCode && this.setupMenuCode();
-        blockMenu.banClass('functionInit', true);
-        blockMenu.unbanClass('functionEdit', true);
-    } else {
-        !workspace.isVimMode() && blockMenu.unbanClass('functionInit', true);
-        blockMenu.banClass('functionEdit', true);
-    }
-    blockMenu.lastSelector === 'func' && blockMenu.align();
-};
-
-Entry.Func.prototype.edit = function() {
-    if (Entry.Func.isEdit) {
-        return;
-    }
-    Entry.Func.isEdit = true;
-    Entry.getMainWS().blockMenu.deleteRendered('variable');
-    if (!Entry.Func.svg) {
-        const result = Entry.Func.initEditView();
-        Entry.Func.isEdit = result;
-    } else {
-        this.parentView.appendChild(this.svg);
-    }
-};
-
-Entry.Func.generateBlock = function(func) {
-    const blockSchema = Entry.block[`func_${func.id}`];
-    const block = {
-        template: blockSchema.template,
-        params: blockSchema.params,
-    };
-
-    const reg = /(%\d)/im;
-    const templateParams = blockSchema.template.split(reg);
-    let description = '';
-    let booleanIndex = 0;
-    let stringIndex = 0;
-    for (const i in templateParams) {
-        const templateChunk = templateParams[i];
-        if (reg.test(templateChunk)) {
-            const paramIndex = Number(templateChunk.split('%')[1]) - 1;
-            const param = blockSchema.params[paramIndex];
-            if (param.type === 'Indicator') {
-            } else if (param.accept === 'boolean') {
-                description +=
-                    Lang.template.function_param_boolean + (booleanIndex ? booleanIndex : '');
-                booleanIndex++;
-            } else {
-                description +=
-                    Lang.template.function_param_string + (stringIndex ? stringIndex : '');
-                stringIndex++;
-            }
+    static updateMenu() {
+        const workspace = Entry.getMainWS();
+        if (!workspace) {
+            return;
+        }
+        const blockMenu = workspace.getBlockMenu();
+        if (this.targetFunc) {
+            !this.menuCode && this.setupMenuCode();
+            blockMenu.banClass('functionInit', true);
+            blockMenu.unbanClass('functionEdit', true);
         } else {
-            description += templateChunk;
+            !workspace.isVimMode() && blockMenu.unbanClass('functionInit', true);
+            blockMenu.banClass('functionEdit', true);
         }
+        blockMenu.lastSelector === 'func' && blockMenu.align();
     }
 
-    return { block, description };
-};
-
-Entry.Func.prototype.generateBlock = function(toSave) {
-    const generatedInfo = Entry.Func.generateBlock(this);
-    this.block = generatedInfo.block;
-    this.description = generatedInfo.description;
-};
-
-Entry.Func.generateWsBlock = function(targetFunc, isRestore) {
-    this.unbindFuncChangeEvent();
-    targetFunc = targetFunc ? targetFunc : this.targetFunc;
-    const defBlock = targetFunc.content.getEventMap('funcDef')[0];
-
-    if (!defBlock) {
-        return;
-    }
-
-    let outputBlock = defBlock.params[0];
-    let booleanIndex = 0;
-    let stringIndex = 0;
-    const schemaParams = [];
-    let schemaTemplate = '';
-    const hashMap = targetFunc.hashMap;
-    const paramMap = targetFunc.paramMap;
-    const blockIds = [];
-
-    while (outputBlock) {
-        const value = outputBlock.params[0];
-        const valueType = value.type;
-        switch (outputBlock.type) {
-            case 'function_field_label':
-                schemaTemplate = `${schemaTemplate} ${value}`;
-                break;
-            case 'function_field_boolean':
-                Entry.Mutator.mutate(valueType, {
-                    template: `${Lang.Blocks.FUNCTION_logical_variable} ${booleanIndex + 1}`,
-                });
-                hashMap[valueType] = false;
-                paramMap[valueType] = booleanIndex + stringIndex;
-                booleanIndex++;
-                schemaParams.push({
-                    type: 'Block',
-                    accept: 'boolean',
-                });
-                schemaTemplate += ` %${booleanIndex + stringIndex}`;
-                blockIds.push(outputBlock.id);
-                break;
-            case 'function_field_string':
-                Entry.Mutator.mutate(valueType, {
-                    template: `${Lang.Blocks.FUNCTION_character_variable} ${stringIndex + 1}`,
-                });
-                hashMap[valueType] = false;
-                paramMap[valueType] = booleanIndex + stringIndex;
-                stringIndex++;
-                schemaTemplate += ` %${booleanIndex + stringIndex}`;
-                schemaParams.push({
-                    type: 'Block',
-                    accept: 'string',
-                });
-                blockIds.push(outputBlock.id);
-                break;
-        }
-        outputBlock = outputBlock.getOutputBlock();
-    }
-
-    schemaTemplate += ` %${booleanIndex + stringIndex + 1}`;
-    schemaParams.push({
-        type: 'Indicator',
-        img: 'block_icon/func_icon.svg',
-        size: 12,
-    });
-
-    const funcName = `func_${targetFunc.id}`;
-    const block = Entry.block[funcName];
-
-    const originParams = block.params.slice(0, block.params.length - 1);
-    const newParams = schemaParams.slice(0, schemaParams.length - 1);
-    const originParamsLength = originParams.length;
-    const newParamsLength = newParams.length;
-
-    let changeData = {};
-
-    if (newParamsLength > originParamsLength) {
-        const outputBlockIds = targetFunc.outputBlockIds;
-        if (outputBlockIds) {
-            let startPos = 0;
-            while (outputBlockIds[startPos] === blockIds[startPos]) {
-                startPos++;
-            }
-
-            let endPos = 0;
-            while (
-                outputBlockIds[outputBlockIds.length - endPos - 1] ===
-                blockIds[blockIds.length - endPos - 1]
-            ) {
-                endPos++;
-            }
-
-            endPos = blockIds.length - endPos - 1;
-            changeData = {
-                type: 'insert',
-                startPos,
-                endPos,
-            };
-        }
-    } else if (newParamsLength < originParamsLength) {
-        changeData = {
-            type: 'cut',
-            pos: newParamsLength,
+    static generateBlock(func) {
+        const blockSchema = Entry.block[`func_${func.id}`];
+        const block = {
+            template: blockSchema.template,
+            params: blockSchema.params,
         };
-    } else {
-        changeData = { type: 'noChange' };
+
+        const reg = /(%\d)/im;
+        const templateParams = blockSchema.template.split(reg);
+        let description = '';
+        let booleanIndex = 0;
+        let stringIndex = 0;
+        for (const i in templateParams) {
+            const templateChunk = templateParams[i];
+            if (reg.test(templateChunk)) {
+                const paramIndex = Number(templateChunk.split('%')[1]) - 1;
+                const param = blockSchema.params[paramIndex];
+                if (param.type === 'Indicator') {
+                } else if (param.accept === 'boolean') {
+                    description +=
+                        Lang.template.function_param_boolean + (booleanIndex ? booleanIndex : '');
+                    booleanIndex++;
+                } else {
+                    description +=
+                        Lang.template.function_param_string + (stringIndex ? stringIndex : '');
+                    stringIndex++;
+                }
+            } else {
+                description += templateChunk;
+            }
+        }
+
+        return { block, description };
     }
 
-    changeData.isRestore = isRestore;
+    static generateWsBlock(targetFunc, isRestore) {
+        this.unbindFuncChangeEvent();
+        targetFunc = targetFunc ? targetFunc : this.targetFunc;
+        const defBlock = targetFunc.content.getEventMap('funcDef')[0];
 
-    targetFunc.outputBlockIds = blockIds;
+        if (!defBlock) {
+            return;
+        }
 
-    Entry.Mutator.mutate(
-        funcName,
-        {
-            params: schemaParams,
-            template: schemaTemplate,
-        },
-        changeData
-    );
+        let outputBlock = defBlock.params[0];
+        let booleanIndex = 0;
+        let stringIndex = 0;
+        const schemaParams = [];
+        let schemaTemplate = '';
+        const hashMap = targetFunc.hashMap;
+        const paramMap = targetFunc.paramMap;
+        const blockIds = [];
 
-    for (const key in hashMap) {
-        const state = hashMap[key];
-        if (state) {
-            const text = /string/.test(key)
-                ? Lang.Blocks.FUNCTION_character_variable
-                : Lang.Blocks.FUNCTION_logical_variable;
+        while (outputBlock) {
+            const value = outputBlock.params[0];
+            const valueType = value.type;
+            switch (outputBlock.type) {
+                case 'function_field_label':
+                    schemaTemplate = `${schemaTemplate} ${value}`;
+                    break;
+                case 'function_field_boolean':
+                    Entry.Mutator.mutate(valueType, {
+                        template: `${Lang.Blocks.FUNCTION_logical_variable} ${booleanIndex + 1}`,
+                    });
+                    hashMap[valueType] = false;
+                    paramMap[valueType] = booleanIndex + stringIndex;
+                    booleanIndex++;
+                    schemaParams.push({
+                        type: 'Block',
+                        accept: 'boolean',
+                    });
+                    schemaTemplate += ` %${booleanIndex + stringIndex}`;
+                    blockIds.push(outputBlock.id);
+                    break;
+                case 'function_field_string':
+                    Entry.Mutator.mutate(valueType, {
+                        template: `${Lang.Blocks.FUNCTION_character_variable} ${stringIndex + 1}`,
+                    });
+                    hashMap[valueType] = false;
+                    paramMap[valueType] = booleanIndex + stringIndex;
+                    stringIndex++;
+                    schemaTemplate += ` %${booleanIndex + stringIndex}`;
+                    schemaParams.push({
+                        type: 'Block',
+                        accept: 'string',
+                    });
+                    blockIds.push(outputBlock.id);
+                    break;
+            }
+            outputBlock = outputBlock.getOutputBlock();
+        }
 
-            Entry.Mutator.mutate(key, { template: text });
+        schemaTemplate += ` %${booleanIndex + stringIndex + 1}`;
+        schemaParams.push({
+            type: 'Indicator',
+            img: 'block_icon/func_icon.svg',
+            size: 12,
+        });
+
+        const funcName = `func_${targetFunc.id}`;
+        const block = Entry.block[funcName];
+
+        const originParams = block.params.slice(0, block.params.length - 1);
+        const newParams = schemaParams.slice(0, schemaParams.length - 1);
+        const originParamsLength = originParams.length;
+        const newParamsLength = newParams.length;
+
+        let changeData = {};
+
+        if (newParamsLength > originParamsLength) {
+            const outputBlockIds = targetFunc.outputBlockIds;
+            if (outputBlockIds) {
+                let startPos = 0;
+                while (outputBlockIds[startPos] === blockIds[startPos]) {
+                    startPos++;
+                }
+
+                let endPos = 0;
+                while (
+                    outputBlockIds[outputBlockIds.length - endPos - 1] ===
+                    blockIds[blockIds.length - endPos - 1]
+                ) {
+                    endPos++;
+                }
+
+                endPos = blockIds.length - endPos - 1;
+                changeData = {
+                    type: 'insert',
+                    startPos,
+                    endPos,
+                };
+            }
+        } else if (newParamsLength < originParamsLength) {
+            changeData = {
+                type: 'cut',
+                pos: newParamsLength,
+            };
         } else {
-            hashMap[key] = true;
+            changeData = { type: 'noChange' };
+        }
+
+        changeData.isRestore = isRestore;
+
+        targetFunc.outputBlockIds = blockIds;
+
+        Entry.Mutator.mutate(
+            funcName,
+            {
+                params: schemaParams,
+                template: schemaTemplate,
+            },
+            changeData
+        );
+
+        for (const key in hashMap) {
+            const state = hashMap[key];
+            if (state) {
+                const text = /string/.test(key)
+                    ? Lang.Blocks.FUNCTION_character_variable
+                    : Lang.Blocks.FUNCTION_logical_variable;
+
+                Entry.Mutator.mutate(key, { template: text });
+            } else {
+                hashMap[key] = true;
+            }
+        }
+
+        this.bindFuncChangeEvent(targetFunc);
+    }
+
+    static bindFuncChangeEvent(targetFunc) {
+        const selectedTargetFunc = targetFunc ? targetFunc : this.targetFunc;
+        if (!this._funcChangeEvent && selectedTargetFunc.content.getEventMap('funcDef')[0].view) {
+            this._funcChangeEvent = selectedTargetFunc.content
+                .getEventMap('funcDef')[0]
+                .view._contents[1].changeEvent.attach(this, this.generateWsBlock);
         }
     }
 
-    this.bindFuncChangeEvent(targetFunc);
-};
-
-Entry.Func.bindFuncChangeEvent = function(targetFunc) {
-    targetFunc = targetFunc ? targetFunc : this.targetFunc;
-    if (!this._funcChangeEvent && targetFunc.content.getEventMap('funcDef')[0].view) {
-        this._funcChangeEvent = targetFunc.content
-            .getEventMap('funcDef')[0]
-            .view._contents[1].changeEvent.attach(this, this.generateWsBlock);
-    }
-};
-
-Entry.Func.unbindFuncChangeEvent = function() {
-    if (!this._funcChangeEvent) {
-        return;
-    }
-    this._funcChangeEvent.destroy();
-    delete this._funcChangeEvent;
-};
-
-Entry.Func.unbindWorkspaceStateChangeEvent = function() {
-    const event = this._workspaceStateEvent;
-    if (!event) {
-        return;
+    static unbindFuncChangeEvent() {
+        if (!this._funcChangeEvent) {
+            return;
+        }
+        this._funcChangeEvent.destroy();
+        delete this._funcChangeEvent;
     }
 
-    event.destroy();
-    delete this._workspaceStateEvent;
-};
+    static unbindWorkspaceStateChangeEvent() {
+        const event = this._workspaceStateEvent;
+        if (!event) {
+            return;
+        }
+
+        event.destroy();
+        delete this._workspaceStateEvent;
+    }
+
+    static reset() {
+        if (this.isEdit) {
+            this.endEdit();
+        }
+        this.menuCode = undefined;
+    }
+
+    static _generateFunctionSchema(functionId) {
+        const prefixedFunctionId = `func_${functionId}`;
+        if (Entry.block[prefixedFunctionId]) {
+            return;
+        }
+        let BlockSchema = function() {};
+        BlockSchema.prototype = Entry.block.function_general;
+        BlockSchema = new BlockSchema();
+        BlockSchema.changeEvent = new Entry.Event();
+        BlockSchema.template = Lang.template.function_general;
+
+        Entry.block[prefixedFunctionId] = BlockSchema;
+    }
+
+    /**
+     * 이전 워크스페이스 보드 형태가 VIMBOARD 였던 경우면 VIMBOARD 로 돌린다.
+     * @private
+     */
+    static _restoreBoardToVimBoard() {
+        const ws = Entry.getMainWS();
+        if (ws && ws.overlayModefrom === Entry.Workspace.MODE_VIMBOARD) {
+            ws.setMode({
+                boardType: Entry.Workspace.MODE_VIMBOARD,
+                textType: Entry.Vim.TEXT_TYPE_PY,
+                runType: Entry.Vim.WORKSPACE_MODE,
+            });
+            Entry.variableContainer.functionAddButton_.addClass('disable');
+        }
+    }
+
+    constructor(func) {
+        this.id = func && func.id ? func.id : Entry.generateHash();
+        let content;
+        //inspect empty content
+        if (func && func.content && func.content.length > 4) {
+            content = func.content;
+        }
+        this.content = content
+            ? new Entry.Code(content)
+            : new Entry.Code([
+                  [
+                      {
+                          type: 'function_create',
+                          copyable: false,
+                          deletable: false,
+                          x: 40,
+                          y: 40,
+                      },
+                  ],
+              ]);
+        this.block = null;
+        this.blockMenuBlock = null;
+        this.hashMap = {};
+        this.paramMap = {};
+
+        EntryFunc._generateFunctionSchema(this.id);
+
+        if (func && func.content) {
+            const blockMap = this.content._blockMap;
+            for (const key in blockMap) {
+                EntryFunc.registerParamBlock(blockMap[key].type);
+            }
+            EntryFunc.generateWsBlock(this);
+        }
+
+        EntryFunc.registerFunction(this);
+
+        EntryFunc.updateMenu();
+    }
+
+    destroy() {
+        this.blockMenuBlock && this.blockMenuBlock.destroy();
+    }
+
+    edit() {
+        if (EntryFunc.isEdit) {
+            return;
+        }
+        EntryFunc.isEdit = true;
+        Entry.getMainWS().blockMenu.deleteRendered('variable');
+        if (!EntryFunc.svg) {
+            EntryFunc.isEdit = EntryFunc.initEditView();
+        } else {
+            this.parentView.appendChild(this.svg);
+        }
+    }
+
+    generateBlock() {
+        const generatedInfo = EntryFunc.generateBlock(this);
+        this.block = generatedInfo.block;
+        this.description = generatedInfo.description;
+    }
+}
+
+Entry.Func = EntryFunc;

--- a/src/class/function.js
+++ b/src/class/function.js
@@ -294,12 +294,11 @@ class EntryFunc {
             if (reg.test(templateChunk)) {
                 const paramIndex = Number(templateChunk.split('%')[1]) - 1;
                 const param = blockSchema.params[paramIndex];
-                if (param.type === 'Indicator') {
-                } else if (param.accept === 'boolean') {
+                if (param.accept === 'boolean') {
                     description +=
                         Lang.template.function_param_boolean + (booleanIndex ? booleanIndex : '');
                     booleanIndex++;
-                } else {
+                } else if (param.type !== 'Indicator') {
                     description +=
                         Lang.template.function_param_string + (stringIndex ? stringIndex : '');
                     stringIndex++;

--- a/src/class/function.js
+++ b/src/class/function.js
@@ -37,10 +37,11 @@ class EntryFunc {
     }
 
     static edit(func) {
+        let funcElement = func;
         if (typeof func === 'string') {
-            func = Entry.variableContainer.getFunction(/(func_)?(.*)/.exec(func)[2]);
+            funcElement = Entry.variableContainer.getFunction(/(func_)?(.*)/.exec(func)[2]);
         }
-        if (!func) {
+        if (!funcElement) {
             console.error('no function');
             return;
         }
@@ -49,22 +50,22 @@ class EntryFunc {
 
         this.cancelEdit();
 
-        this.targetFunc = func;
+        this.targetFunc = funcElement;
         EntryFunc.isEdit = true;
         Entry.getMainWS().blockMenu.deleteRendered('variable');
-        if (this.initEditView(func.content) === false) {
+        if (this.initEditView(funcElement.content) === false) {
             EntryFunc.isEdit = false;
             return;
         } // edit fail
-        this.bindFuncChangeEvent(func);
+        this.bindFuncChangeEvent(funcElement);
         this.updateMenu();
         setTimeout(() => {
-            const schema = Entry.block[`func_${func.id}`];
+            const schema = Entry.block[`func_${funcElement.id}`];
             if (schema && schema.paramsBackupEvent) {
                 schema.paramsBackupEvent.notify();
             }
 
-            this._backupContent = func.content.stringify();
+            this._backupContent = funcElement.content.stringify();
         }, 0);
     }
 
@@ -245,18 +246,18 @@ class EntryFunc {
     }
 
     static createParamBlock(type, blockPrototype, originalType) {
-        originalType = /string/gi.test(originalType)
+        const originalTypeFullName = /string/gi.test(originalType)
             ? 'function_param_string'
             : 'function_param_boolean';
-        let blockSchema = function() {};
-        blockSchema.prototype = blockPrototype;
-        blockSchema = new blockSchema();
-        blockSchema.changeEvent = new Entry.Event();
-        blockSchema.template = Lang.template[originalType];
-        blockSchema.fontColor = blockPrototype.fontColor || '#FFF';
+        let BlockSchema = function() {};
+        BlockSchema.prototype = blockPrototype;
+        BlockSchema = new BlockSchema();
+        BlockSchema.changeEvent = new Entry.Event();
+        BlockSchema.template = Lang.template[originalTypeFullName];
+        BlockSchema.fontColor = blockPrototype.fontColor || '#FFF';
 
-        Entry.block[type] = blockSchema;
-        return blockSchema;
+        Entry.block[type] = BlockSchema;
+        return BlockSchema;
     }
 
     static updateMenu() {
@@ -311,9 +312,9 @@ class EntryFunc {
         return { block, description };
     }
 
-    static generateWsBlock(targetFunc, isRestore) {
+    static generateWsBlock(target, isRestore) {
         this.unbindFuncChangeEvent();
-        targetFunc = targetFunc ? targetFunc : this.targetFunc;
+        const targetFunc = target ? target : this.targetFunc;
         const defBlock = targetFunc.content.getEventMap('funcDef')[0];
 
         if (!defBlock) {

--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -601,9 +601,9 @@ Entry.VariableContainer = class VariableContainer {
             .addClass('attr_box')
             .appendTo(localList);
 
-        const { globalV, localV } = _.groupBy(this.variables_, ({ object_ }) => {
-            return object_ ? 'localV' : 'globalV';
-        });
+        const { globalV, localV } = _.groupBy(this.variables_, ({ object_ }) =>
+            object_ ? 'localV' : 'globalV'
+        );
 
         const gLength = (globalV || []).length;
         const lLength = (localV || []).length;
@@ -683,9 +683,9 @@ Entry.VariableContainer = class VariableContainer {
             .addClass('attr_box')
             .appendTo(localList);
 
-        const { localV, globalV } = _.groupBy(this.lists_, ({ object_ }) => {
-            return object_ ? 'localV' : 'globalV';
-        });
+        const { localV, globalV } = _.groupBy(this.lists_, ({ object_ }) =>
+            object_ ? 'localV' : 'globalV'
+        );
 
         const gLength = (globalV || []).length;
         const lLength = (localV || []).length;
@@ -2989,6 +2989,7 @@ Entry.VariableContainer = class VariableContainer {
         this._messageRefs = [];
         this._functionRefs = [];
 
+        Entry.Func.reset();
         playground.reloadPlayground();
         this.updateList();
     }
@@ -3148,7 +3149,7 @@ Entry.VariableContainer = class VariableContainer {
         const variables = this.variables_;
         const variableJSON = v.toJSON();
         variableJSON.variableType = type;
-        let newVariable = Entry.Variable.create(variableJSON);
+        const newVariable = Entry.Variable.create(variableJSON);
         variables.splice(variables.indexOf(v), 0, newVariable);
         if (value !== undefined) {
             variableJSON.value = value;

--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -2285,6 +2285,7 @@ Entry.VariableContainer = class VariableContainer {
         Entry.container.inputValue = answer;
         Entry.container.inputValue.setName(Lang.Blocks.VARIABLE_get_canvas_input_value);
     }
+
     generateStt(answer) {
         answer =
             answer ||

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -275,25 +275,10 @@ Entry.cancelObjectEdit = function({ target, type }) {
     const objectView = object.view_;
     const isCurrent = $(objectView).find(target).length !== 0;
     const tagName = target.tagName.toUpperCase();
-    if (!object.isEditing || ((tagName === 'INPUT' && isCurrent) || type === 'touchstart')) {
+    if (!object.isEditing || (tagName === 'INPUT' && isCurrent) || type === 'touchstart') {
         return;
     }
     object.editObjectValues(false);
-};
-
-Entry.generateFunctionSchema = function(functionId) {
-    functionId = `func_${functionId}`;
-    if (Entry.block[functionId]) {
-        return;
-    }
-    let BlockSchema = function() {};
-    const blockPrototype = Entry.block.function_general;
-    BlockSchema.prototype = blockPrototype;
-    BlockSchema = new BlockSchema();
-    BlockSchema.changeEvent = new Entry.Event();
-    BlockSchema.template = Lang.template.function_general;
-
-    Entry.block[functionId] = BlockSchema;
 };
 
 Entry.getMainWS = function() {


### PR DESCRIPTION
clearProject 시 함수편집모드의 문제 발생하던 문제를 수정하였습니다.

- clearProject -> loadProject 시 함수 편집모드의 함수인자블록들이 나오지 않던 문제
- 편집모드에서 clear -> load 로 새 프로젝트 시작한 경우 함수편집모드가 더이상 안열리던 문제
  - edit 모드 플래그를 그대로 둔 상태로 초기화되어버리기 때문에 문제 발생
  - endEdit 함수를 통해 함수편집모드 종료 후 refresh 하도록 설정

---

- 문제가 여태 발견되지 않았던 것은, Entry web 이 새프로젝트 = 페이지 refresh 이기 때문

- 관련 파일들 lint 적용 (private method 는 적용하지 않았습니다. 린트가 자꾸 잡아서 일단..)
- Entry.Func 클래스화
  - Entry.Func 는 instance 와 Entry.Func 에 함수를 붙여 쓴 코드를 혼용하고있어서 static 처리했습니다.
