### PR TITLE
[issue/11459] issue/11302 의 사이드이펙트 처리

### DIFF
--- a/src/playground/block.js
+++ b/src/playground/block.js
@@ -547,6 +547,7 @@ Entry.Block = class Block {
 
     doDestroy(animate) {
         this.destroy(animate);
+        this.thread && this.thread.updateValueBlock();
         this.getCode().changeEvent.notify();
         return this;
     }


### PR DESCRIPTION
- destroyBelow 커맨드가 아닌 destroy 커맨드로 처리시,
  블록이 완전삭제 되었음에도 valueBlock 을 새로 업데이트 해주지 않아 빈공간으로 보이는 문제수정