### PR TITLE
[비디오 블록] fs Warning supress

### DIFF
--- a/webpack_config/common.js
+++ b/webpack_config/common.js
@@ -19,6 +19,9 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.json'],
     },
+    node: {
+        fs: 'empty',
+    },
     module: {
         rules: [
             {


### PR DESCRIPTION
video.worker.ts에서 사용하는 face-api.js에서 fs에 대한 warning을 supress하기 위해 fs를 webpack 에서 제거