### PR TITLE
[DataTable] modalChart props 이전 전달 방식으로 수정

### DIFF
--- a/src/class/DataTable.js
+++ b/src/class/DataTable.js
@@ -211,26 +211,14 @@ class DataTable {
     }
 
     createChart(source) {
-        const { chart: charts = [], fields, origin } = source;
-        const tables = charts.reduce((prevChart, chart) => {
-            if (chart.categoryIndexes.length === 0) {
-                return prevChart;
-            }
-            return [
-                ...prevChart,
-                {
-                    chart,
-                    table: [fields, ...origin],
-                },
-            ];
-        }, []);
+        const { chart = [], fields, rows } = source;
         const container = Entry.Dom('div', {
             class: 'entry-table-chart',
             parent: $('body'),
         })[0];
         return new ModalChart({
             data: {
-                source: { tables },
+                source: { fields, origin: rows, chart },
             },
             container,
         });


### PR DESCRIPTION
  - 블럭 실행 중 변동 사항 적용 안됨