### PR TITLE
라인 WS 로딩 이슈 수정

### DIFF
--- a/src/playground/blocks/index.js
+++ b/src/playground/blocks/index.js
@@ -49,8 +49,12 @@ Entry.EXPANSION_BLOCK_LIST = {
 function getBlockObject(items) {
     const blockObject = {};
     items.forEach((item) => {
-        if ('getBlocks' in item) {
-            Object.assign(blockObject, item.getBlocks());
+        try {
+            if ('getBlocks' in item) {
+                Object.assign(blockObject, item.getBlocks());
+            }
+        } catch (err) {
+            console.log(err, item);
         }
     });
     return blockObject;


### PR DESCRIPTION
라인 WS 로딩 이슈 수정 입니다. entryjs가 다시 빌드 되면서 올라가서 생기는 문제로 보입니다. 라인에서는 AI 관련 컨텐츠가 없어서 다국어쪽에서 없는것을 코드 에러로 잡아서 생기는 이슈입니다.