### PR TITLE
[#2896] 스크롤이 최상단이 아니면 작품 실행 시 마우스 포인터의 위치가 맞지 않는 현상

### DIFF
--- a/src/class/stage.js
+++ b/src/class/stage.js
@@ -107,16 +107,11 @@ Entry.Stage = class Stage {
 
         const moveFunc = (e) => {
             e.preventDefault();
-            const { pageX, pageY } = Entry.Utils.convertMouseEvent(e);
+            const { offsetY, offsetX } = Entry.Utils.convertMouseEvent(e);
             const roundRect = Entry.stage.getBoundRect();
-            const scrollPos = Entry.Utils.getScrollPos();
             this.mouseCoordinate = {
-                x: Entry.Utils.toFixed(
-                    ((pageX - roundRect.left - scrollPos.left) / roundRect.width - 0.5) * 480
-                ),
-                y: Entry.Utils.toFixed(
-                    ((pageY - roundRect.top - scrollPos.top) / roundRect.height - 0.5) * -270
-                ),
+                x: Entry.Utils.toFixed((offsetX / roundRect.width - 0.5) * 480),
+                y: Entry.Utils.toFixed((offsetY / roundRect.height - 0.5) * -270),
             };
             Entry.dispatchEvent('stageMouseMove');
         };


### PR DESCRIPTION
[stage] stage 좌표계산 변경
  - 스크롤이 생긴이후의 좌표가 변경되면서 좌표계산 오류
  - stage의 좌표를 계산해보려는 식이 기대와 다르게 동작
  - offsetY를 이용하여 수정