### PR TITLE
[하쌤보드] 초음파센서 핀번호 초기값 변경

### DIFF
--- a/src/playground/blocks/hardware/block_hasseam.js
+++ b/src/playground/blocks/hardware/block_hasseam.js
@@ -744,11 +744,11 @@ Entry.Hasseam.getBlocks = function() {
                 params: [
                     {
                         type: 'text',
-                        params: ['4'],
+                        params: ['16'],
                     },
                     {
                         type: 'text',
-                        params: ['5'],
+                        params: ['17'],
                     },
                 ],
                 type: 'hasseam_get_digital_ultrasonic',


### PR DESCRIPTION
초음파센서의 포트 초기값 각각 변경
trig 16, echo 17