### PR TITLE
이슈 2949 처리

### DIFF
--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1497,9 +1497,6 @@ Entry.setCloneBrush = function(sprite, parentBrush) {
     }
 
     const shape = GEHelper.brushHelper.newShape(brush);
-    if (isWebGL) {
-        brush.setCurrentPath(parentBrush.getCurrentPath());
-    }
     shape.entity = sprite;
     const selectedObjectContainer = Entry.stage.selectedObjectContainer;
     selectedObjectContainer.addChildAt(shape, selectedObjectContainer.getChildIndex(sprite.object));


### PR DESCRIPTION
[#2949](https://oss.navercorp.com/entry/entry2/issues/2949)

이전에 pixi 5 로직을 revert할때 복원된 코드가 다시 5적용할때 빠지지 않아 오류 발생