### PR TITLE
파이썬 변환 버그 방어 코드 추가

### DIFF
--- a/src/playground/workspace.js
+++ b/src/playground/workspace.js
@@ -34,7 +34,7 @@ Entry.Workspace = class Workspace {
                 option.dom,
                 option.align,
                 option.categoryData,
-                option.scroll,
+                option.scroll
             );
             this._destroyer.add(this.blockMenu);
             this.blockMenu.workspace = this;
@@ -169,6 +169,9 @@ Entry.Workspace = class Workspace {
                     mode.runType = VIM.WORKSPACE_MODE;
                 }
                 e.block && Entry.getMainWS() && Entry.getMainWS().board.activateBlock(e.block);
+            } finally {
+                this.oldMode = 1;
+                this.mode = 1;
             }
         };
 


### PR DESCRIPTION
https://github.com/entrylabs/entryjs/issues/2075 이슈 관련 수정입니다.
일단 Entry.workspace쪽에서 python 모드 변환시에 블럭 치환하는 부분에서 모드가 왔다 갔다 가면서 파이썬 모드로 최종적으로 진입하지 않는 부분이 있었습니다. 이에 대해서 강제로 파이썬 모드, mode ==1 로 바꿔주도록 하였습니다 