### PR TITLE
이슈 4082 처리

### DIFF
--- a/src/class/engine.js
+++ b/src/class/engine.js
@@ -1005,11 +1005,23 @@ Entry.Engine = class Engine {
                     popup.window_.appendChild(Entry.targetChecker.getStatusView()[0]);
                 }
             }
+
+            if (window.top !== window.self) {
+                window.top.addEventListener('mousemove', this.copyMouseMoveEvent);
+            }
         } else {
+            if (window.top !== window.self) {
+                window.top.removeEventListener('mousemove', this.copyMouseMoveEvent);
+            }
             this.popup.remove();
             this.popup = null;
         }
         Entry.windowResized.notify();
+    }
+
+    copyMouseMoveEvent(event) {
+        const eventClone = new event.constructor(event.type, event);
+        window.self.dispatchEvent(eventClone);
     }
 
     closeFullScreen() {


### PR DESCRIPTION
[#4082](https://oss.navercorp.com/entry/entry2/issues/4082)

작품상세 의 경우 iframe으로 실제 이벤트는 iframe -> window에 mousemove이벤트가 걸려있으니

fullscreen이 되면서 iframe밖으로 나오면서 window.top 부분에는 mousemove 이벤트가 없어서 실제로는 이벤트 처리가 안됨.

이때 처리방법에는 fullscreen방식을 현재 방식에서 iframe을 전체로 팝업화 하는 방식과

현재 처리한것처럼 이벤트를 강제로 dispatch 하는 방식이 있는데 각각 장단점이 있어 고민이 되는 지점.