### PR TITLE
[#4219] 엔트리파이썬 모드 일부 글상자 블록 실행 오류 수정

### DIFF
--- a/src/playground/blocks/block_text.js
+++ b/src/playground/blocks/block_text.js
@@ -272,7 +272,7 @@ module.exports = {
                     sprite.setTextEffect(effect, mode);
                     return script.callReturn();
                 },
-                syntax: { js: [], py: ['Entry.changeTextEffect(%1, %2)'] },
+                syntax: { js: [], py: ['Entry.changeTextEffect("%1", "%2")'] },
             },
             text_change_font: {
                 color: EntryStatic.colorSet.block.default.TEXT,
@@ -307,7 +307,7 @@ module.exports = {
                     sprite.setFontWithLog(`${sprite.getFontSize()} ${font}`, false);
                     return script.callReturn();
                 },
-                syntax: { js: [], py: ['Entry.text_change_font(%1)'] },
+                syntax: { js: [], py: ['Entry.text_change_font("%1")'] },
             },
             text_change_font_color: {
                 color: EntryStatic.colorSet.block.default.TEXT,
@@ -339,7 +339,7 @@ module.exports = {
                     sprite.setColorWithLog(color);
                     return script.callReturn();
                 },
-                syntax: { js: [], py: ['Entry.text_change_font_color(%1)'] },
+                syntax: { js: [], py: ['Entry.text_change_font_color("%1")'] },
             },
             text_change_bg_color: {
                 color: EntryStatic.colorSet.block.default.TEXT,
@@ -371,7 +371,7 @@ module.exports = {
                     sprite.setBGColourWithLog(color);
                     return script.callReturn();
                 },
-                syntax: { js: [], py: ['Entry.text_change_bg_color(%1)'] },
+                syntax: { js: [], py: ['Entry.text_change_bg_color("%1")'] },
             },
             text_flush: {
                 color: EntryStatic.colorSet.block.default.TEXT,

--- a/src/textcoding/parser/core/text/pyToBlock.js
+++ b/src/textcoding/parser/core/text/pyToBlock.js
@@ -964,6 +964,8 @@ Entry.PyToBlockParser = class {
                 }
 
                 return object;
+            case 'fonts':
+                return EntryStatic.fonts.find(({ family }) => family === value).family;
             case 'objectSequence':
         }
     }

--- a/src/textcoding/static/codeMap.js
+++ b/src/textcoding/static/codeMap.js
@@ -192,6 +192,15 @@ Entry.CodeMap = {};
                 hide: 'HIDE',
             },
         ],
+        text_change_font: [
+            EntryStatic.fonts.reduce(
+                (obj, { family }) => ({
+                    ...obj,
+                    [family.toLowerCase()]: family,
+                }),
+                {}
+            ),
+        ],
     };
 
     cc.Arduino = {


### PR DESCRIPTION
[#4219](https://oss.navercorp.com/entry/entry2/issues/4219)
- 글상자 일부 블록 엔트리파이썬 모드 syntax 오류 수정
- 엔트리파이썬 모드에서 실행/정지 시 글씨체 설정이 None 으로 변경되는 오류 수정