### PR TITLE
[DataTable] 차트가 2개 이상일 때 먼저 연 차트로만 조회되는 현상

### DIFF
--- a/src/class/DataTable.js
+++ b/src/class/DataTable.js
@@ -240,7 +240,7 @@ class DataTable {
             source.modal = this.createChart(source, chartIndex);
         }
         source.forceApply();
-        source.modal.show({ chartIndex });
+        source.modal.show(undefined, { chartIndex });
         this.modal = source.modal;
     }
 


### PR DESCRIPTION
[#4466](https://oss.navercorp.com/entry/entry2/issues/4466)

  - props말고 data에 정보를 넣어 보냄




