### PR TITLE
[#2096] 오브젝트 상태 변경 시 숫자가 아닌 값을 입력하면, 오브젝트의 크기가 비정상적으로 변경 

### DIFF
--- a/src/playground/blocks/block_looks.js
+++ b/src/playground/blocks/block_looks.js
@@ -136,7 +136,7 @@ module.exports = {
                         message = Entry.convertToRoundedDecimals(message, 3);
                         new Entry.Dialog(sprite, message, mode);
                         sprite.syncDialogVisible(sprite.getVisible());
-                        setTimeout(function() {
+                        setTimeout(() => {
                             script.timeFlag = 0;
                         }, timeValue * 1000);
                     }

--- a/src/playground/scope.js
+++ b/src/playground/scope.js
@@ -124,7 +124,7 @@ class Scope {
     }
 
     getNumberValue(key, scope) {
-        return parseFloat(this.getValue(key, scope));
+        return parseFloat(this.getValue(key, scope)) || 0;
     }
 
     getBooleanValue(key, scope) {


### PR DESCRIPTION
[#2096](https://oss.navercorp.com/entry/entry2/issues/2096)


해당 위치에 getNumberValue || 0 으로 할까하다가 getNumberValue의 리턴하는 쪽에서 처리했습니다