### PR TITLE
[#4557] 끝 블록을 포함한 블록 묶음을 다른 블록에 조립하면 WS프리징

### DIFF
--- a/src/playground/block_view.js
+++ b/src/playground/block_view.js
@@ -716,6 +716,7 @@ Entry.BlockView = class BlockView {
         delete this.isVerticalMove;
         delete this.mouseDownCoordinate;
         delete this.dragInstance;
+        delete this.magnetsOfThread;
     }
 
     vimBoardEvent(event, type, block) {
@@ -881,8 +882,10 @@ Entry.BlockView = class BlockView {
         const { scale = 1 } = board || {};
         const x = this.x / scale;
         const y = this.y / scale;
-        const magnets = this._getMagnetsInThread();
-        for (const type in magnets) {
+        if (!this.magnetsOfThread) {
+            this.magnetsOfThread = this._getMagnetsInThread();
+        }
+        for (const type in this.magnetsOfThread) {
             const view = _.result(
                 board.getNearestMagnet(x, type === 'next' ? y + this.getBelowHeight() : y, type),
                 'view'

--- a/src/playground/block_view.js
+++ b/src/playground/block_view.js
@@ -855,6 +855,23 @@ Entry.BlockView = class BlockView {
         delete this.originPos;
     }
 
+    _getMagnetsInThread() {
+        const magnet = {};
+
+        const previous = this.magnet.previous;
+        if (previous) {
+            magnet.previous = previous;
+        }
+
+        const lastBlock = this.block.thread.getLastBlock();
+        const next = lastBlock.view.magnet.next;
+        if (next) {
+            magnet.next = next;
+        }
+
+        return magnet;
+    }
+
     _updateCloseBlock() {
         if (!this._skeleton.magnets) {
             return;
@@ -864,7 +881,8 @@ Entry.BlockView = class BlockView {
         const { scale = 1 } = board || {};
         const x = this.x / scale;
         const y = this.y / scale;
-        for (const type in this.magnet) {
+        const magnets = this._getMagnetsInThread();
+        for (const type in magnets) {
             const view = _.result(
                 board.getNearestMagnet(x, type === 'next' ? y + this.getBelowHeight() : y, type),
                 'view'
@@ -1171,8 +1189,10 @@ Entry.BlockView = class BlockView {
         this.disableMouseEvent = false;
         this.moveTo(0, 0, false);
         const { _nextGroup: parentSvgGroup, _nextCommentGroup: parentCommentGroup } = view;
-        parentSvgGroup.appendChild(this.svgGroup);
-        parentCommentGroup && parentCommentGroup.appendChild(this.svgCommentGroup);
+        parentSvgGroup && parentSvgGroup.appendChild && parentSvgGroup.appendChild(this.svgGroup);
+        parentCommentGroup &&
+            parentCommentGroup.appendChild &&
+            parentCommentGroup.appendChild(this.svgCommentGroup);
     }
 
     _toGlobalCoordinate(dragMode, doNotUpdatePos) {


### PR DESCRIPTION
[#4557](https://oss.navercorp.com/entry/entry2/issues/4557)

드래그로 선택한 블럭의 magnet을 가져와 검사하기 때문에 발생한 issue.
thread의 마지막에 달린 블럭을 가져와서 검사하도록 수정