### PR TITLE
[#4352] 엔트리파이썬 모드 계산 > 몫, 나머지 블록 오류 수정

### DIFF
--- a/src/playground/block_entry.js
+++ b/src/playground/block_entry.js
@@ -132,6 +132,8 @@ function getConverters() {
             '/': 'DIVIDE',
             AND: 'and',
             OR: 'or',
+            QUOTIENT: '//',
+            MOD: '%',
         };
         return map[value];
     };

--- a/src/playground/blocks/block_calc.js
+++ b/src/playground/blocks/block_calc.js
@@ -670,9 +670,8 @@ module.exports = {
                     js: [],
                     py: [
                         {
-                            syntax: '(%2 // %4)',
-                            template: '%2 // %4',
-                            params: [null, null, null, null, null, 'QUOTIENT'],
+                            syntax: '(%2 %6 %4)',
+                            template: '%2 %6 %4',
                             blockType: 'param',
                             textParams: [
                                 undefined,
@@ -695,37 +694,7 @@ module.exports = {
                                     value: 'QUOTIENT',
                                     fontSize: 11,
                                     arrowColor: EntryStatic.colorSet.arrow.default.CALC,
-                                    converter: Entry.block.converters.returnStringValue,
-                                },
-                            ],
-                        },
-                        {
-                            syntax: '(%2 % %4)',
-                            template: '%2 % %4',
-                            params: [null, null, null, null, null, 'MOD'],
-                            blockType: 'param',
-                            textParams: [
-                                undefined,
-                                {
-                                    type: 'Block',
-                                    accept: 'string',
-                                },
-                                undefined,
-                                {
-                                    type: 'Block',
-                                    accept: 'string',
-                                },
-                                undefined,
-                                {
-                                    type: 'Dropdown',
-                                    options: [
-                                        [Lang.Blocks.CALC_quotient_and_mod_sub_1, 'QUOTIENT'],
-                                        [Lang.Blocks.CALC_quotient_and_mod_sub_2, 'MOD'],
-                                    ],
-                                    value: 'QUOTIENT',
-                                    fontSize: 11,
-                                    arrowColor: EntryStatic.colorSet.arrow.default.CALC,
-                                    converter: Entry.block.converters.returnStringValue,
+                                    converter: Entry.block.converters.returnOperator,
                                 },
                             ],
                         },

--- a/src/textcoding/parser/core/block/blockToPy.js
+++ b/src/textcoding/parser/core/block/blockToPy.js
@@ -126,7 +126,7 @@ Entry.BlockToPyParser = class {
             let tokenProcessed = token;
             // 이재원 #7994 관련하여 만약 token (text input) 에 시작하는 템플릿이 괄호라면,
             // 그리고 하나의 Param만 가지고 있는 경우를 regex check 후에 slice해서 사용.
-            if (_blockTokens.length == 1 && /^\([%[\d ]+\)/gim.test(tokenProcessed)) {
+            if (_blockTokens.length == 1 && /^\(%[\d ]+\)/gim.test(tokenProcessed)) {
                 tokenProcessed = tokenProcessed.slice(1, -1);
             }
             const paramsTemplate = tokenProcessed.match(_blockParamRegex);


### PR DESCRIPTION
[#4352](https://oss.navercorp.com/entry/entry2/issues/4352)
- 엔트리파이썬 모드에서 나머지 계산 dropdown이 노출되지 않는 오류 수정
- 괄호 제거 정규식 패턴 오류 수정