### PR TITLE
[#4347] 엔트리파이썬 모드 keyboardCode map의 충돌 key 제거

### DIFF
--- a/src/textcoding/static/keyboardCode.js
+++ b/src/textcoding/static/keyboardCode.js
@@ -111,8 +111,6 @@ Entry.KeyboardCode = {};
         backslash: 220,
 
         // legacy keyinput support
-        '8': 8,
-        '9': 9,
         '13': 13,
         '16': 16,
         '17': 17,


### PR DESCRIPTION
[#4347](https://oss.navercorp.com/entry/entry2/issues/4347)
파이썬모드에서 ascii를 직접 입력하는 경우 대응을 위해 추가된 키 값 중 
8(Backspace), 9(Tab)가 기존 키와 중복되어 정상적으로 동작하지 않아 제거 처리