### PR TITLE
Entry.engine.isContinue 관련 함수 제거

### DIFF
--- a/src/class/engine.js
+++ b/src/class/engine.js
@@ -1247,15 +1247,3 @@ Entry.Engine = class Engine {
         });
     }
 };
-
-Entry.Engine.computeThread = function(entity, script) {
-    Entry.engine.isContinue = true;
-    let isSame = false;
-    while (script && Entry.engine.isContinue && !isSame) {
-        Entry.engine.isContinue = !script.isRepeat;
-        const newScript = script.run();
-        isSame = newScript && newScript === script;
-        script = newScript;
-    }
-    return script;
-};

--- a/src/class/function.js
+++ b/src/class/function.js
@@ -20,18 +20,6 @@ class EntryFunc {
         func.blockMenuBlock = this._targetFuncBlock;
     }
 
-    static executeFunction(threadHash) {
-        let script = this.threads[threadHash];
-        script = Entry.Engine.computeThread(script.entity, script);
-        if (script) {
-            this.threads[threadHash] = script;
-            return true;
-        } else {
-            delete this.threads[threadHash];
-            return false;
-        }
-    }
-
     static clearThreads() {
         this.threads = {};
     }

--- a/src/core/promiseManager.js
+++ b/src/core/promiseManager.js
@@ -49,22 +49,6 @@ module.exports = class PromiseManager {
     }
 
     /**
-     * TimeWaitManager 를 통해 일시정지기능이 포함된 sleep.
-     * 재시작시 남은 시간만큼 이어서 시작한다.
-     * 
-     * @param time 일시정지할 ms
-     * @param blockId 해당 블럭의 id. script.block.id 로 가져올 수 있다.
-     */
-    sleepWithPause(time, blockId) {
-        return this.Promise((resolve) => {
-            Entry.TimeWaitManager.add(blockId, () => {
-                Entry.engine.isContinue = false;
-                resolve();
-            }, time);
-        });
-    }
-
-    /**
      * sample code
      * Entry.addEventListener('callApi', ({url}, resolve, reject) => {
      *     $.ajax(url).then((...args) => {


### PR DESCRIPTION
금일 코드리뷰하였던 Entry.engine.isContinue 관련 함수들 삭제하였습니다.

삭제한 함수는 아래와 같습니다.
- src/class/engine.js > function.executeFunction(threadHash) 에서만 사용
- src/class/function.js > executeFunction(threadHash) : 사용처 없음
- src/core/promiseManager.js > sleepWithPause(time, blockId) : 사용처 없음