### PR TITLE
[4.14.0][#4827][object] 오브젝트 이름 영역에 우측 클릭 시, 오브젝트 이름 수정이 가능한 현상

### DIFF
--- a/src/class/object.js
+++ b/src/class/object.js
@@ -1216,6 +1216,17 @@ Entry.EntryObject = class {
                 e.preventDefault();
             }
         });
+        nameView.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            if (!_.includes(this.view_.classList, 'selectedObject')) {
+                this._rightClick(e);
+            }
+        });
+        nameView.addEventListener('focus', () => {
+            if (!_.includes(this.view_.classList, 'selectedObject')) {
+                nameView.blur();
+            }
+        });
 
         const onKeyPressed = Entry.Utils.whenEnter(() => {
             this.editObjectValues(false);


### PR DESCRIPTION
[#4827](https://oss.navercorp.com/entry/entry2/issues/4827)

  - 우측 클릭 시에도, 오브젝트 관련 메뉴 노출