### PR TITLE
[#5034] 함수 파라미터 사용 중에 파이썬 모드로 전환 시 코드 변환 오류 수정

### DIFF
--- a/src/textcoding/parser/core/block/blockToPy.js
+++ b/src/textcoding/parser/core/block/blockToPy.js
@@ -107,7 +107,8 @@ Entry.BlockToPyParser = class {
                 return syntax;
             }
         } else if (this.isFuncStmtParam(block)) {
-            results.push(block.data.type);
+            const type = block.data.type;
+            results.push(this._funcParamMap.get(type) || type);
         }
 
         if (!syntax && !this.isFuncStmtParam(block)) {
@@ -154,8 +155,17 @@ Entry.BlockToPyParser = class {
             if (statements) {
                 statements.forEach((value) => {
                     const [, index] = value.split('$');
+                    const statementTextCodes = [];
+                    const thread = block.statements[index - 1];
+                    thread.getBlocks().forEach((block) => {
+                        if (this.getFuncInfo(block)) {
+                            statementTextCodes.push(this.makeFuncDef(block, true));
+                        } else {
+                            statementTextCodes.push(this.Block(block));
+                        }
+                    });
                     resultTextCode += Entry.TextCodingUtil.indent(
-                        this.Thread(block.statements[index - 1])
+                        statementTextCodes.join('\n').concat('\n')
                     );
                 });
             }


### PR DESCRIPTION
[#5034](https://oss.navercorp.com/entry/entry2/issues/5034)
- 함수 파라미터 이름 변환 오류 수정
- 함수 statement와 블럭 statement의 텍스트 코드 변환 로직 동일하게 변경