### PR TITLE
cancelEdit 할때 generateWsBlock에서 restore하지 않도록 처리

### DIFF
--- a/src/class/function.js
+++ b/src/class/function.js
@@ -407,7 +407,7 @@ class EntryFunc {
                 this.targetFunc.localVariables = this._backupOption.localVariables;
                 this.changeType(this.targetFunc, this._backupOption.type);
                 this._generateFunctionSchema(this.targetFunc.id);
-                this.generateWsBlock(this.targetFunc, true);
+                this.generateWsBlock(this.targetFunc);
             }
         }
         Entry.variableContainer.updateList();


### PR DESCRIPTION
[#5655](https://oss.navercorp.com/entry/entry2/issues/5655)