### PR TITLE
[oss #7013] 하드웨어 웹연결 webpack5 대응

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@types/isomorphic-fetch": "^0.0.35",
         "audiobuffer-to-wav": "^1.0.0",
         "autoprefixer": "^9.4.3",
+        "buffer": "^6.0.3",
         "core-js": "^3.6.4",
         "crypto-js": "^4.0.0",
         "cuid": "^2.1.6",

--- a/src/class/entryModuleLoader.ts
+++ b/src/class/entryModuleLoader.ts
@@ -1,11 +1,15 @@
 import fetch from 'isomorphic-fetch';
 import cryptojs from 'crypto-js';
 import HardwareLite from './hw_lite';
+import { EntryBlock, EntryBlockModule, EntryHardwareBlockModule } from '../../types/index';
+
 type EntryBlockRegisterSchema = {
     blockName: string;
     block: EntryBlock;
     isBlockShowBlockMenu?: boolean;
 };
+
+const { Entry, EntryStatic, Lang } = window;
 
 class EntryModuleLoader {
     public moduleList: string[] = [];

--- a/src/class/hardware/hardwareMonitor.ts
+++ b/src/class/hardware/hardwareMonitor.ts
@@ -1,3 +1,6 @@
+import { EntryHardwareBlockModule } from '../../../types/index';
+
+const { Entry } = window;
 const hwMonitorSvgTemplate =
     '<svg id="hwMonitor" width="100%" height="100%"' +
     'version="1.1" xmlns="http://www.w3.org/2000/svg"></svg>';

--- a/src/class/hw.ts
+++ b/src/class/hw.ts
@@ -4,6 +4,12 @@ import createHardwarePopup from './hardware/functions/createHardwarePopup';
 import ExternalProgramLauncher from './hardware/externalProgramLauncher';
 // eslint-disable-next-line prettier/prettier
 import PopupHelper from './popup_helper';
+import {
+    HardwareMessageData,
+    WebSocketMessage,
+    EntryHardwareBlockModule,
+    UnknownAny,
+} from '../../types/index';
 
 enum HardwareModuleType {
     builtIn = 'builtin',
@@ -15,6 +21,8 @@ enum HardwareStatement {
     socketConnected = 'socketConnected',
     hardwareConnected = 'hardwareConnected',
 }
+
+const { Entry, Lang } = window;
 
 export default class Hardware {
     get httpsServerAddress() {
@@ -634,15 +642,17 @@ export default class Hardware {
             if (!dontShowChecked) {
                 const title = Lang.Msgs.hardware_need_update_title;
                 const content = Lang.Msgs.hardware_need_update_content;
-                Entry.modal.alert(content, title, {
-                    withDontShowAgain: true
-                }).then((data: { dontShowChecked: boolean }) => {
-                    const { dontShowChecked } = data || {};
-                    if (dontShowChecked) {
-                        localStorage.setItem('skipNoticeHWOldVersion', 'true');
-                    }
-                    resolve(null);
-                })
+                Entry.modal
+                    .alert(content, title, {
+                        withDontShowAgain: true,
+                    })
+                    .then((data: { dontShowChecked: boolean }) => {
+                        const { dontShowChecked } = data || {};
+                        if (dontShowChecked) {
+                            localStorage.setItem('skipNoticeHWOldVersion', 'true');
+                        }
+                        resolve(null);
+                    });
             } else {
                 resolve(null);
             }

--- a/src/class/hw_lite.ts
+++ b/src/class/hw_lite.ts
@@ -1,7 +1,7 @@
 import throttle from 'lodash/throttle';
-import { TextEncoder } from 'util';
 import ExtraBlockUtils from '../util/extrablockUtils';
 import HardwareMonitor from './hardware/hardwareMonitor';
+import { EntryHardwareLiteBlockModule } from '../../types/index';
 
 enum HardwareStatement {
     disconnected = 'disconnected',
@@ -10,7 +10,9 @@ enum HardwareStatement {
     connectFailed = 'connectFailed',
 }
 
+const { Entry, Lang } = window;
 const ARDUINO_BOARD_IDS: string[] = ['1.1', '4.2', '8.1'];
+const Buffer = require('buffer/').Buffer;
 
 class LineBreakTransformer {
     private container: string;
@@ -49,7 +51,6 @@ export default class HardwareLite {
     static isHwLiteSupportAgent: any;
     private playground: any;
     private connectionType: 'ascii' | 'bytestream' | undefined;
-    textEncoder: TextEncoder;
     private hwMonitor?: HardwareMonitor;
     private isSendAsyncRun: boolean;
     private sendAsyncWithThrottle: any;
@@ -148,7 +149,11 @@ export default class HardwareLite {
         // INFO: 디바이스가 모바일이거나 일렉트론이면 1차적으로 제외
         if (userAgentString.includes('mobile') || userAgentString.includes('electron')) {
             return false;
-        } else if (userAgentString.includes('whale') || userAgentString.includes('edge') || userAgentString.includes('chrome')) {
+        } else if (
+            userAgentString.includes('whale') ||
+            userAgentString.includes('edge') ||
+            userAgentString.includes('chrome')
+        ) {
             return true;
         } else {
             return false;

--- a/src/class/intro.ts
+++ b/src/class/intro.ts
@@ -2,6 +2,9 @@
  * 프로퍼티 패널쪽에서 프로젝트의 속성을 보여주는 뷰를 담당
  * @use entry-lms
  */
+
+import { IEntry } from '../../types/index';
+
 class EntryIntro implements IEntry.Intro {
     public modes: any = {};
     public selected: any = undefined;
@@ -29,4 +32,4 @@ class EntryIntro implements IEntry.Intro {
 }
 
 export default EntryIntro;
-Entry.Intro = EntryIntro;
+window.Entry.Intro = EntryIntro;

--- a/src/class/property_panel.ts
+++ b/src/class/property_panel.ts
@@ -1,3 +1,5 @@
+import { EntryDom } from '../../types/index';
+
 class PropertyPanel {
     public modes: any = {};
     public selected: string = undefined;

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -1,3 +1,5 @@
+import { EntryDom, EntryDomConstructor } from '../../types/index';
+
 type HandleableClickEvent = JQuery.ClickEvent & { handled: boolean };
 
 const createEntryDom: EntryDomConstructor = function(tag, options) {

--- a/src/playground/block_menu.ts
+++ b/src/playground/block_menu.ts
@@ -11,6 +11,9 @@ import find from 'lodash/find';
 import ModelClass from '../core/modelClass';
 import Hammer from 'hammerjs';
 
+import { EntryDom } from '../../types/index';
+
+const Entry = window.Entry;
 const VARIABLE = 'variable';
 const HW = 'arduino';
 const practicalCourseCategoryList = ['hw_motor', 'hw_melody', 'hw_sensor', 'hw_led', 'hw_robot'];
@@ -1307,7 +1310,7 @@ class BlockMenu extends ModelClass<Schema> {
     }
 
     private _captureKeyEvent(e: KeyboardEvent) {
-        let keyCode = Entry.Utils.inputToKeycode(e);
+        const keyCode = Entry.Utils.inputToKeycode(e);
         if (!keyCode) {
             return;
         }

--- a/src/util/videoUtils.ts
+++ b/src/util/videoUtils.ts
@@ -50,6 +50,8 @@ type DetectedObject = {
 };
 type IndicatorType = 'pose' | 'face' | 'object';
 
+const { Entry, Lang } = window;
+
 export const getInputList = async () => {
     if (navigator.mediaDevices) {
         return (await navigator.mediaDevices.enumerateDevices()) || [];

--- a/src/util/videoUtils.ts
+++ b/src/util/videoUtils.ts
@@ -2,6 +2,7 @@
  * nt11576 Lee.Jaewon
  * commented area with "motion test" is for the motion detection testing canvas to test the computer vision, uncomment all codes labeled "motion test"
  */
+import { MediaUtilsInterface } from '../../types/index';
 
 import { GEHelper } from '../graphicEngine/GEHelper';
 import VideoWorker from './workers/video.worker.ts';
@@ -299,7 +300,7 @@ class VideoUtils implements MediaUtilsInterface {
                 };
                 const weightsUrl = this.getWeightUrl();
                 this.worker.postMessage({
-                    weightsUrl: weightsUrl,
+                    weightsUrl,
                     type: 'init',
                     width: this.CANVAS_WIDTH,
                     height: this.CANVAS_HEIGHT,

--- a/types/entry.d.ts
+++ b/types/entry.d.ts
@@ -1,5 +1,7 @@
 /// <reference path="./index.d.ts" />
 
+import { ISkeleton, EntryBlock, UnknownAny } from './index';
+
 declare interface EntryOptions {
     hardwareEnable?: boolean;
     mediaFilePath?: string;
@@ -12,7 +14,7 @@ declare interface EntryOptions {
 /**
  * 엔트리 실제 인스턴스에 대한 정의
  */
-declare interface IEntry extends EntryOptions {
+export declare interface IEntry extends EntryOptions {
     Func: any;
     externalModulesLite: any;
     loadLiteTestModule: (file: file, name: string) => Promise<void>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,7 @@ declare type Point = {
     y: number;
 };
 
-declare interface ISkeleton {
+export declare interface ISkeleton {
     executable?: boolean;
     fontSize?: number;
     movable?: boolean;
@@ -42,7 +42,7 @@ declare interface ISkeleton {
     statementPos?: (blockView: any) => Point[];
 }
 
-declare interface MediaUtilsInterface {
+export declare interface MediaUtilsInterface {
     initialize(list?: string[][]): void;
 
     reset(): void;
@@ -62,18 +62,18 @@ declare interface EntryDomOptions {
     parent?: EntryDom;
 }
 
-declare interface EntryDom extends JQuery {
+export declare interface EntryDom extends JQuery {
     innerHTML?: string;
     textContent?: string;
     bindOnClick?: (e: any) => this;
 }
 
-declare type EntryDomConstructor = (
+export declare type EntryDomConstructor = (
     tag: string | HTMLElement | JQuery,
     options?: EntryDomOptions
 ) => EntryDom;
 
-interface HardwareMessageData extends HardwareModuleId {
+export interface HardwareMessageData extends HardwareModuleId {
     [key: string]: any;
 }
 
@@ -82,7 +82,7 @@ interface HardwareModuleId {
     model: string;
 }
 
-type WebSocketMessage = {
+export type WebSocketMessage = {
     data: string;
     mode: number;
     type: 'utf8';
@@ -90,7 +90,7 @@ type WebSocketMessage = {
 
 declare module SerialPort {}
 
-declare module IEntry {
+export declare module IEntry {
     export interface Container {
         resizeEvent: any; // Entry.Event
         splitterEnable?: boolean;
@@ -142,7 +142,7 @@ declare module IEntry {
     // Entry namespace 에 필요한 객체가 있으면 추가해주세요.
 }
 
-declare type EntryBlock = {
+export declare type EntryBlock = {
     color: string;
     outerLine?: string;
     skeleton: string;
@@ -170,14 +170,14 @@ declare type EntryBlock = {
 };
 
 // expansion blocks 의 스키마를 따름
-declare interface EntryBlockModule {
+export declare interface EntryBlockModule {
     name: string;
     title: { [key: string]: string };
     description?: string;
     getBlocks: () => { [blockName: string]: EntryBlock };
 }
 
-declare interface EntryHardwareBlockModule extends EntryBlockModule {
+export declare interface EntryHardwareBlockModule extends EntryBlockModule {
     // 홍보용
     imageName: string;
     url: string;
@@ -201,7 +201,7 @@ declare interface EntryHardwareBlockModule extends EntryBlockModule {
     dataHandler?: (data: HardwareMessageData) => void;
 }
 
-declare interface EntryHardwareLiteBlockModule extends EntryBlockModule {
+export declare interface EntryHardwareLiteBlockModule extends EntryBlockModule {
     getMonitorPort(): Object;
     duration: number;
     // 홍보용

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -1,10 +1,15 @@
-declare interface Window {
-    entrylms: any;
-    Lang: any;
-    popupHelper?: import('../src/class/popup_helper').default;
-    EntryStatic: any;
-    ImageCapture: any;
-    sendSync: any | undefined;
+import { IEntry } from './entry';
+
+declare global {
+    interface Window {
+        entrylms: any;
+        Lang: any;
+        popupHelper?: import('../src/class/popup_helper').default;
+        EntryStatic: any;
+        ImageCapture: any;
+        sendSync: any | undefined;
+        Entry: IEntry;
+    }
 }
 
 declare var Lang: any;

--- a/webpack_config/common.js
+++ b/webpack_config/common.js
@@ -5,6 +5,7 @@ const autoprefixer = require('autoprefixer');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     entry: {
@@ -22,6 +23,7 @@ module.exports = {
             crypto: false,
             buffer: false,
             perf_hooks: false,
+            buffer: require.resolve('buffer/'),
         },
         extensions: ['.ts', '.tsx', '.js', '.json'],
         mainFields: ['jsnext:main', 'browser', 'main'],
@@ -141,6 +143,9 @@ module.exports = {
             root: path.join(__dirname, '..'),
         }),
         new WebpackManifestPlugin(),
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+        }),
         new MiniCssExtractPlugin({
             // Options similar to the same options in webpackOptions.output
             // both options are optional

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,11 @@ base64-arraybuffer@0.1.5:
   resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz"
@@ -3319,6 +3324,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -5700,6 +5713,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   integrity sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==
   dependencies:
     postcss "^7.0.14"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
https://oss.navercorp.com/entry/entry2/issues/7013

- 웹팩5에서는 nodejs 기본 모듈인 Buffer가 사용 불가능하므로, package.json에서 브라우저용 Buffer 라이브러리 추가
- 웹팩5에서는 타입지정 파일을 암묵적으로 전역사용이 불가능하므로, import & export 지정