### PR TITLE
[하드웨어] 마이크로비트 통신 채널 지정 오류

### DIFF
--- a/src/playground/blocks/hardware/block_microbit2.js
+++ b/src/playground/blocks/hardware/block_microbit2.js
@@ -1823,7 +1823,7 @@ Entry.Microbit2 = new (class Microbit2 {
                 def: {
                     type: 'microbit2_radio_setting',
                 },
-                paramsKeyMap: { RATE: 0, CHANNEL: 1 },
+                paramsKeyMap: { CHANNEL: 0 },
                 func: (sprite, script) => {
                     if (!Entry.Utils.isNumber(script.getNumberValue('CHANNEL'))) {
                         return;

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -2767,10 +2767,16 @@ Entry.Utils.pauseSoundInstances = function() {
     Entry.soundInstances.getAllValues().forEach((instance) => {
         instance.paused = true;
     });
+    Entry.bgmInstances.getAllValues().forEach((instance) => {
+        instance.paused = true;
+    });
 };
 
 Entry.Utils.recoverSoundInstances = function() {
     Entry.soundInstances.getAllValues().forEach((instance) => {
+        instance.paused = false;
+    });
+    Entry.bgmInstances.getAllValues().forEach((instance) => {
         instance.paused = false;
     });
 };


### PR DESCRIPTION
마이크로비트 통신 관련 채널 설정 블럭의 오류입니다.

해당 블럭은 1개의 인자만을 받지만, 코드에서 2개의 인자를 받으며, 2번째 인자의 값을 파싱함으로 항상 0의 값만을 반환하여 채널을 설정하게 됩니다. 

다만,,, 이 코드를 고쳐도 통신관련 코드가 정상적으로 동작하지 않습니다. 마이크로비트의 펌웨어 코드에서 뭔가 오류가 있을 것으로 추정되는데 마이크로비트 펌웨어 로우 파일은 공개되지 않는 것인가요?