### PR TITLE
ToyBot 서보모터 속도 수정

### DIFF
--- a/src/playground/blocks/hardware/block_jinirobot_toybot.js
+++ b/src/playground/blocks/hardware/block_jinirobot_toybot.js
@@ -599,8 +599,7 @@ Entry.toybot.getBlocks = function() {
                         ['1', 1],
                         ['2', 2],
                         ['3', 3],
-                        ['4', 4],
-                        ['5', 5]
+                        ['4', 4]
                     ],
                     value: 3,
                     fontSize: 11,


### PR DESCRIPTION
지니로봇 ToyBot 블록 수정
1. ToyBot 서보모터 드랍다운 목록에서 속도를 4까지로 제한하였습니다.