### PR TITLE
로봇아이 AI Camera 모드 순서 변경

### DIFF
--- a/src/playground/blocks/hardware/block_robotisRBPracticalAssembly.js
+++ b/src/playground/blocks/hardware/block_robotisRBPracticalAssembly.js
@@ -7325,11 +7325,11 @@ Entry.Robotis_rb_P_Assembly.getBlocks = function () {
                     type: 'Dropdown',
                     options: [
                         [Lang.Blocks.robotis_huskylens_mode_face_recognition, '0'],
+                        [Lang.Blocks.robotis_huskylens_mode_expression_recognition, '9'],
                         [Lang.Blocks.robotis_huskylens_mode_line_tracking, '3'],
                         [Lang.Blocks.robotis_huskylens_mode_color_recognition, '4'],
                         [Lang.Blocks.robotis_huskylens_mode_tag_recognition, '5'],
                         [Lang.Blocks.robotis_huskylens_mode_object_classification, '6'],
-                        [Lang.Blocks.robotis_huskylens_mode_expression_recognition, '9'],
                     ],
                     value: '0',
                     fontSize: 11,

--- a/src/playground/blocks/hardwareLite/block_robotis_robotai_lite.js
+++ b/src/playground/blocks/hardwareLite/block_robotis_robotai_lite.js
@@ -7237,11 +7237,11 @@ let camera_id_for_use = 0;
                             type: 'Dropdown',
                             options: [
                                 [Lang.Blocks.robotis_ai_camera_mode_face_recognition, '0'],
+                                [Lang.Blocks.robotis_ai_camera_mode_expression_recognition, '9'],
                                 [Lang.Blocks.robotis_ai_camera_mode_line_tracking, '3'],
                                 [Lang.Blocks.robotis_ai_camera_mode_color_recognition, '4'],
                                 [Lang.Blocks.robotis_ai_camera_mode_tag_recognition, '5'],
                                 [Lang.Blocks.robotis_ai_camera_mode_object_classification, '6'],
-                                [Lang.Blocks.robotis_ai_camera_mode_expression_recognition, '9'],
                             ],
                             value: '0',
                             fontSize: 11,


### PR DESCRIPTION
- 로봇아이 AI Camera 모드 순서 변경(표정 인식을 2번째로 이동)