### PR TITLE
continueLoop 로직 수정

### DIFF
--- a/src/playground/executors.js
+++ b/src/playground/executors.js
@@ -228,11 +228,17 @@ class Executor {
         if (this._callStack.length) {
             this.scope = this._callStack.pop();
         }
-        const schema = Entry.block[this.scope.block.type];
-        if (schema.class === 'condition') {
+        else {
+            return Entry.STATIC.PASS;
+        }
+        while (this._callStack.length) {
+            const schema = Entry.block[this.scope.block.type];
+            if (schema.class === 'repeat') {
+                break;
+            }
             this.scope = this._callStack.pop();
         }
-        return Entry.STATIC.BREAK;
+        return Entry.STATIC.CONTINUE;
     }
 
     end() {


### PR DESCRIPTION
현재 로직은 continueLoop를 사용하는 블럭을 조건문으로 2개 이상 감쌌을 경우 제대로 작동하지 않습니다.

기타 변경사항에 대한 설명은 #2907 에 주석과 함께 적어뒀으니 참고 부탁드립니다.