### PR TITLE
소리 관련 블럭에서 대기할 때 일시정지한 동안의 시간도 포함하는 오류 해결

### DIFF
--- a/src/playground/blocks/block_sound.js
+++ b/src/playground/blocks/block_sound.js
@@ -293,12 +293,10 @@ module.exports = {
                             script.playState = 1;
                             const instance = Entry.Utils.playSound(sound.id);
                             Entry.Utils.addSoundInstances(instance, sprite);
-                            const duration = Math.floor(
-                                (sound.duration * 1000) / Entry.playbackRateValue
-                            );
-                            setTimeout(() => {
+
+                            instance.on('complete', () => {
                                 script.playState = 0;
-                            }, duration);
+                            });
                         }
                         return script;
                     } else if (script.playState == 1) {
@@ -381,14 +379,13 @@ module.exports = {
                         const sound = sprite.parent.getSound(soundId);
                         if (sound) {
                             script.playState = 1;
-                            const instance = Entry.Utils.playSound(sound.id);
+                            const duration = script.getNumberValue('SECOND', script) * 1000;
+                            const instance = Entry.Utils.playSound(sound.id, { duration });
                             Entry.Utils.addSoundInstances(instance, sprite);
-                            const timeValue = script.getNumberValue('SECOND', script);
-                            setTimeout(() => {
-                                instance.stop();
+
+                            instance.on('complete', () => {
                                 script.playState = 0;
-                            }, timeValue * 1000);
-                            instance.addEventListener('complete', (e) => {});
+                            });
                         }
                         return script;
                     } else if (script.playState == 1) {
@@ -498,9 +495,9 @@ module.exports = {
                             });
                             Entry.Utils.addSoundInstances(instance, sprite);
 
-                            setTimeout(() => {
+                            instance.on('complete', () => {
                                 script.playState = 0;
-                            }, duration);
+                            });
                         }
                         return script;
                     } else if (script.playState == 1) {

--- a/src/playground/executors.js
+++ b/src/playground/executors.js
@@ -228,11 +228,17 @@ class Executor {
         if (this._callStack.length) {
             this.scope = this._callStack.pop();
         }
-        const schema = Entry.block[this.scope.block.type];
-        if (schema.class === 'condition') {
+        else {
+            return Entry.STATIC.PASS;
+        }
+        while (this._callStack.length) {
+            const schema = Entry.block[this.scope.block.type];
+            if (schema.class === 'repeat') {
+                break;
+            }
             this.scope = this._callStack.pop();
         }
-        return Entry.STATIC.BREAK;
+        return Entry.STATIC.CONTINUE;
     }
 
     end() {

--- a/src/playground/executors.js
+++ b/src/playground/executors.js
@@ -235,7 +235,7 @@ class Executor {
             }
             this.scope = this._callStack.pop();
         }
-        return Entry.STATIC.CONTINUE;
+        return Entry.STATIC.BREAK;
     }
 
     end() {


### PR DESCRIPTION
## 개요
[block_sound.js](https://github.com/entrylabs/entryjs/blob/develop/src/playground/blocks/block_sound.js)에서,
"소리 재생하고 기다리기" 관련 블럭이 일시정지 했을 때에도 대기가 멈추지 않습니다.
따라서, 특정 소리를 재생하고 기다린다고 할 때, 중간에 일시정지를 했다가 해제하면,
소리의 재생이 끝나기도 전에 다음 블럭이 실행됩니다.

## 수정 내역
현재 소리를 재생하고 기다리는 블럭은
`sound_something_wait_with_block`, `sound_something_second_wait_with_block`, `sound_from_to_and_wait`
이 3가지인데,
해당 블럭은 전부 `setInterval`을 이용해 대기를 하기 때문에 일시정지의 영향을 받지 않습니다.
해당 로직을 soundInstance의 `complete` 리스너로 변경했습니다.
추가적으로, ~초 재생하고 기다리기 코드는 음악 중단에 `setInterval`을 사용하고 있었기 때문에
`Entry.Utils.playSound`의 `duration` 옵션으로 변경하였습니다.