### PR TITLE
Entry.hw.portData 초기화 조건 수정

### DIFF
--- a/src/playground/blocks/hardware/block_robotis.js
+++ b/src/playground/blocks/hardware/block_robotis.js
@@ -51,9 +51,12 @@ Entry.Robotis_carCont = {
             this.update();
             return script.callReturn();
         }
-        // clear portData only if not RB-100 practical kit
+        // clear portData only if not RB-100
         if (Entry.hw.hwModule.id != "7.A,7.B" &&
-            Entry.hw.hwModule.id != "7.C" ) {
+            Entry.hw.hwModule.id != "7.C"  &&
+            Entry.hw.hwModule.id != "7.5,7.6"  &&
+            Entry.hw.hwModule.id != "7.7,7.8" &&
+            Entry.hw.hwModule.id != "7.9") {
             Entry.hw.portData = {};
         }
         setTimeout(function() {


### PR DESCRIPTION
알쥐, 알라, 꼭두 로봇의 경우 write 블록 실행후 Entry.hw.portData 초기화를 하지 않음.