### PR TITLE
리스트 5000개 초과 토스트를 alert에서 warning으로 변경

### DIFF
--- a/src/class/variable/listVariable.js
+++ b/src/class/variable/listVariable.js
@@ -15,7 +15,7 @@ class ListVariable extends Variable {
     }
 
     _showListFullWarning() {
-        Entry.toast?.alert(
+        Entry.toast?.warning(
             Lang?.Workspace?.list_cant_add_item || 'Warning',
             Lang?.Workspace?.list_max_length_exceeded ||
                 `You can add up to ${this.LIST_MAX_LENGTH} items to a list.`

--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -3053,7 +3053,7 @@ Entry.VariableContainer = class VariableContainer {
 
             if (value >= limitValue) {
                 value = limitValue;
-                Entry.toast?.alert(
+                Entry.toast?.warning(
                     Lang?.Workspace?.list_cant_add_item || 'Warning',
                     Lang?.Workspace?.list_max_length_exceeded ||
                         'You can add up to 5,000 items to a list.'
@@ -3084,7 +3084,7 @@ Entry.VariableContainer = class VariableContainer {
                 const selectedLength = array_.length;
 
                 if (selectedLength >= limitValue) {
-                    Entry.toast?.alert(
+                    Entry.toast?.warning(
                         Lang?.Workspace?.list_cant_add_item || 'Warning',
                         Lang?.Workspace?.list_max_length_exceeded ||
                             'You can add up to 5,000 items to a list.'


### PR DESCRIPTION
## 🐛 문제 상황

- 리스트 변수에 5,000개 이상 항목을 추가하려 할 때 `Entry.toast?.alert()`로 알림을 표시하고 있음
- `alert`는 에러성 알림에 사용되는 레벨이므로, 단순 안내 목적의 메시지에는 적절하지 않음
- 사용자에게 과도한 경고 느낌을 줄 수 있음

## ✅ 해결 방안

### 1. `Entry.toast?.alert()` → `Entry.toast?.warning()`으로 변경
- 리스트 최대 길이 초과 시 표시되는 토스트 알림의 레벨을 `warning`으로 하향 조정
- 변경 대상 3곳:
  - `listVariable.js` — `_showListFullWarning()` 메서드
  - `variable_container.js` — 리스트 길이 입력 onblur 핸들러
  - `variable_container.js` — 리스트 항목 추가(plus) 버튼 핸들러

## 🎯 예상 영향 범위

- 리스트 변수에 5,000개 이상 항목 추가 시도 시 토스트 스타일이 `alert` → `warning`으로 변경됨
- 기능 동작(항목 추가 차단)에는 변화 없음
- 사용자에게 보다 부드러운 안내 메시지로 표시됨
