### PR TITLE
[fix] prototype pollution을 통한 Stored XSS 취약점 차단

### DIFF
--- a/src/playground/blocks/hardware/block_KKMOO.js
+++ b/src/playground/blocks/hardware/block_KKMOO.js
@@ -651,9 +651,16 @@ Entry.kkmoo.getBlocks = function () {
             class: 'Make_Motion',
             isNotFor: ['kkmoo'],
             func: function (sprite, script) {
-                const motnum = script.getField('MOTNUM', script);
+                const motnum = Number(script.getField('MOTNUM', script));
                 const angle = script.getValue('ANGLE', script);
                 Entry.hw.update();
+                if (
+                    !Number.isInteger(motnum) ||
+                    motnum < 0 ||
+                    motnum >= Entry.kkmoo.motData.length
+                ) {
+                    return script;
+                }
                 if (script.isStart != true) {
                     script.isStart = true;
                     if (angle >= -90 && angle <= 90) {
@@ -853,8 +860,15 @@ Entry.kkmoo.getBlocks = function () {
             class: 'Save_Motion',
             isNotFor: ['kkmoo'],
             func: function (sprite, script) {
-                const motnum = script.getField('FRAME', script);
+                const motnum = Number(script.getField('FRAME', script));
                 Entry.hw.update();
+                if (
+                    !Number.isInteger(motnum) ||
+                    motnum < 0 ||
+                    motnum >= Entry.kkmoo.motionFrame.length
+                ) {
+                    return script;
+                }
                 if (script.isStart != true) {
                     script.isStart = true;
                     var data = Entry.kkmoo.copyObj(Entry.kkmoo.motData);
@@ -972,9 +986,16 @@ Entry.kkmoo.getBlocks = function () {
             class: 'Save_Motion',
             isNotFor: ['kkmoo'],
             func: function (sprite, script) {
-                const motnum = script.getField('FRAME', script);
+                const motnum = Number(script.getField('FRAME', script));
                 const time = script.getValue('TIME', script);
                 Entry.hw.update();
+                if (
+                    !Number.isInteger(motnum) ||
+                    motnum < 0 ||
+                    motnum >= Entry.kkmoo.motionFrame.length
+                ) {
+                    return script;
+                }
                 if (script.isStart != true) {
                     script.isStart = true;
                     Entry.kkmoo.motionFrame[motnum].time = time;

--- a/src/playground/scope.js
+++ b/src/playground/scope.js
@@ -27,7 +27,11 @@ class Scope {
     static _reservedKeywords = new Set(['__proto__']);
 
     filterReservedKeywords(param) {
-        return Scope._reservedKeywords.has(param) ? '' : param;
+        // 배열/객체를 객체 키로 사용할 때 toString 변환(예: ["__proto__"] → "__proto__")으로
+        // 예약어를 우회하는 것을 차단한다.
+        const normalized =
+            typeof param === 'object' && param !== null ? String(param) : param;
+        return Scope._reservedKeywords.has(normalized) ? '' : param;
     }
 
     getParams() {


### PR DESCRIPTION
## 배경

유저 제보로 확인된 **Stored XSS** 취약점입니다. 특정 블록 조합이 포함된 작품을 **임의의 사용자가 실행하기만 해도**, 작품에 저장된 악성 코드가 prototype pollution을 거쳐 XSS로 실행됩니다.

## 익스플로잇 체인 (검증 완료)

1. **근본 원인 — 예약어 필터 우회** (`src/playground/scope.js`)
   - `filterReservedKeywords`가 `Set.has(param)`으로 **문자열** `"__proto__"`만 차단.
   - 공격자가 param을 배열 `["__proto__"]`로 넣으면 `has`가 `false` → 통과.
   - 이후 객체 키로 쓰이는 순간 JS가 `String(["__proto__"]) === "__proto__"`로 변환하여 우회.

2. **오염 게이트 — kkmoo 하드웨어 블록** (`src/playground/blocks/hardware/block_KKMOO.js`)
   - `kkmoo_set_frame_time`/`kkmoo_set_frame`/`kkmoo_set_motor_degree`에서
     `Entry.kkmoo.motionFrame[motnum]` 등을 인덱스 검증 없이 사용.
   - `motnum`이 배열이면 `motionFrame["__proto__"]` → `Array.prototype` 접근 → **`Array.prototype.time` 오염**.

3. **Sink — DOM innerHTML**
   - 오염된 `Array.prototype.time`이 davinci 블록 실행 흐름을 거쳐 모든 배열의 `.time`으로 노출.
   - `time.entity.parent.scene.inputWrapper.innerHTML`에 `<img src=x onerror=...>` 페이로드가 들어가 Stored XSS 실행.

## 수정 내용

### 1. (근본) `src/playground/scope.js`
`filterReservedKeywords`에서 param이 객체/배열이면 `String()`으로 정규화한 뒤 예약어와 비교. 한 곳 수정으로 `getParam`/`getParams`/`getField` 전 경로의 우회를 차단.
- 차단 키는 **`__proto__`만 유지(호환성 우선)**. 정상 문자열·숫자·객체 param은 영향 없음.

### 2. (심층) `src/playground/blocks/hardware/block_KKMOO.js`
오염 게이트였던 kkmoo 모션 블록 3종에서 `motnum`을 `Number()`로 강제하고 배열 범위를 검증한 뒤에만 인덱싱. 범위 밖이면 무시.

## 검증

- ✅ `filterReservedKeywords` 단위 검증 통과 — `"__proto__"` / `["__proto__"]` → `""`, 정상값은 원본 유지
- ✅ 수정 파일 `node --check` 문법 검증 통과
- ⚠️ jest 스위트는 기존 Babel 플러그인 누락으로 실행 불가(`Tests: 0 total`) — 본 변경과 무관한 환경 문제

## 남은 권고

- 본 PR은 `__proto__`만 차단(호환성 우선). `constructor`/`prototype` 키 변형은 추후 영향도 점검 후 별도 강화 검토 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)