### PR TITLE
[fix] 블록 메뉴 Ctrl+1~9 카테고리 단축키 인덱스 보정

### DIFF
--- a/src/playground/block_menu.ts
+++ b/src/playground/block_menu.ts
@@ -1321,10 +1321,11 @@ class BlockMenu extends ModelClass<Schema> {
             return;
         }
         if (e.ctrlKey && Entry.type === 'workspace' && keyCode > 48 && keyCode < 58) {
+            const categoryIndex = keyCode - 49;
             e.preventDefault();
             setTimeout(() => {
                 this._cancelDynamic(true);
-                this._dSelectMenu(keyCode, true);
+                this._dSelectMenu(categoryIndex, true);
             }, 200);
         }
     }


### PR DESCRIPTION
블록 메뉴에서 Ctrl + 1 ~ Ctrl + 9 단축키가 보이는 블록 카테고리를 순서대로 선택하도록 인덱스 매핑 오류를 수정했습니다.

_captureKeyEvent에서 Ctrl+1-9 입력 시 키 코드(49-57)를 그대로
selectMenu에 넘겨, 숫자 selector를 0 기반 카테고리 인덱스로 해석하는
_convertSelector가 범위를 벗어나 undefined를 반환하던 문제를 수정.
keyCode - 49로 변환한 categoryIndex를 전달해 Ctrl+1→0 ... Ctrl+9→8로 보이는 카테고리를 정상 선택하도록 보정.