### PR TITLE
[fix] Sortable 리스트 순서 변경 시 스크롤 위치 초기화 문제 수정

### DIFF
--- a/src/class/playground.js
+++ b/src/class/playground.js
@@ -704,9 +704,11 @@ Entry.Playground = class Playground {
 
     updatePictureView() {
         if (this.pictureSortableListWidget) {
-            this.pictureSortableListWidget.setData({ items: [] });
-            this.pictureSortableListWidget.setData({
-                items: this._getSortablePictureList(),
+            Entry.Utils.runWithScrollPreserved(this.pictureListView_, () => {
+                this.pictureSortableListWidget.setData({ items: [] });
+                this.pictureSortableListWidget.setData({
+                    items: this._getSortablePictureList(),
+                });
             });
         }
         this.reloadPlayground();
@@ -1102,8 +1104,10 @@ Entry.Playground = class Playground {
 
     updateSoundsView() {
         if (this.soundSortableListWidget) {
-            this.soundSortableListWidget.setData({
-                items: this._getSortableSoundList(),
+            Entry.Utils.runWithScrollPreserved(this.soundListView_, () => {
+                this.soundSortableListWidget.setData({
+                    items: this._getSortableSoundList(),
+                });
             });
         }
 

--- a/src/class/scene.js
+++ b/src/class/scene.js
@@ -172,7 +172,11 @@ Entry.Scene = class {
     updateSceneView() {
         const items = this._getSortableSceneList();
         if (this.sceneSortableListWidget) {
-            setTimeout(() => this.sceneSortableListWidget.setData({ items }), 0);
+            setTimeout(() => {
+                Entry.Utils.runWithScrollPreserved(this.listView_, () => {
+                    this.sceneSortableListWidget.setData({ items });
+                });
+            }, 0);
         }
     }
 

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -479,6 +479,28 @@ Entry.Utils.generateId = function () {
     return `0000${((Math.random() * Math.pow(36, 4)) << 0).toString(36)}`.substr(-4);
 };
 
+/**
+ * Sortable 위젯의 setData 등 리렌더 콜백 실행 중에도
+ * 내부 스크롤 컨테이너(.rcs-inner-container)의 스크롤 위치를 유지한다.
+ * @param {HTMLElement} containerEl Sortable이 마운트된 컨테이너
+ * @param {Function} callback 리스트를 갱신하는 동기 콜백
+ */
+Entry.Utils.runWithScrollPreserved = function (containerEl, callback) {
+    const getScrollEl = () =>
+        containerEl && containerEl.querySelector('.rcs-inner-container');
+    const before = getScrollEl();
+    const top = before ? before.scrollTop : 0;
+    const left = before ? before.scrollLeft : 0;
+
+    callback();
+
+    const after = getScrollEl();
+    if (after) {
+        after.scrollTop = top;
+        after.scrollLeft = left;
+    }
+};
+
 Entry.Utils.randomColor = function () {
     const letters = '0123456789ABCDEF';
     let color = '#';

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -486,8 +486,7 @@ Entry.Utils.generateId = function () {
  * @param {Function} callback 리스트를 갱신하는 동기 콜백
  */
 Entry.Utils.runWithScrollPreserved = function (containerEl, callback) {
-    const getScrollEl = () =>
-        containerEl && containerEl.querySelector('.rcs-inner-container');
+    const getScrollEl = () => containerEl && containerEl.querySelector('.rcs-inner-container');
     const before = getScrollEl();
     const top = before ? before.scrollTop : 0;
     const left = before ? before.scrollLeft : 0;


### PR DESCRIPTION
## 작업 내용
모양/소리/장면 리스트(`@entrylabs/tool`의 `Sortable` 위젯)에서 아이템 순서를 드래그로 바꾸면 리스트 스크롤이 맨 위로 점프하던 문제를 수정
