### PR TITLE
[fix] clear property-usage refs when objects are removed (incl. scene deletion)

### DIFF
--- a/src/class/container.js
+++ b/src/class/container.js
@@ -482,9 +482,11 @@ Entry.Container = class Container {
         const object = this.getObject(id);
         const index = objects.indexOf(object);
 
+        const removedObjectId = object.id;
         object.destroy();
         objects.splice(index, 1);
-        Entry.variableContainer.removeLocalVariables(object.id);
+        Entry.variableContainer.removeLocalVariables(removedObjectId);
+        Entry.variableContainer.removeRefs(removedObjectId);
         Entry.engine.hideProjectTimer();
 
         if (isPass === true) {

--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -3255,6 +3255,18 @@ Entry.VariableContainer = class VariableContainer {
         });
     }
 
+    removeRefs(objectId) {
+        if (!objectId) {
+            return;
+        }
+        ['_variableRefs', '_messageRefs', '_functionRefs'].forEach((type) => {
+            this[type] = this[type].filter(
+                (ref) => !ref.object || ref.object.id !== objectId
+            );
+        });
+        this.view_ && Entry.playground.viewMode_ !== 'default' && this.updateList();
+    }
+
     addRef(type, blockData) {
         const wsMode = _.result(Entry.getMainWS(), 'getMode');
         if (!this.view_ || wsMode !== Entry.Workspace.MODE_BOARD) {


### PR DESCRIPTION
### 오브젝트를 삭제할 때 변수/리스트/신호/함수 속성 패널의 "사용된 오브젝트" 목록에서 해당 오브젝트가 사라지지 않는 버그를 수정합니다.
Entry.VariableContainer의 사용처 ref 배열(_variableRefs, _messageRefs, _functionRefs)에서 삭제된 오브젝트의 ref를 제거합니다. 오브젝트를 직접 삭제하는 경우와 장면 삭제로 오브젝트가 함께 제거되는 경우를 모두 처리합니다.

**Why**

변수/리스트/신호/함수 속성 패널은 위 세 ref 배열을 기반으로 "이 속성을 사용하는 오브젝트"를 표시합니다.

블록을 삭제하면 dataDestroy 이벤트가 removeRef()를 호출하므로 사용처 ref가 정상적으로 제거됩니다. 그러나 오브젝트를 직접 삭제하거나, 장면 삭제가 removeObject(object, true)로 그 장면의 오브젝트를 제거하는 경우에는 오브젝트의 스크립트 블록이 destroy되지 않아 dataDestroy가 발생하지 않습니다. 이때 삭제된 오브젝트의 ref가 배열에 그대로 남아, 이미 없는 오브젝트가 사용처 목록에 계속 표시되고 오브젝트/블록 참조가 메모리에 살아남습니다.

**Implementation**

1. src/class/variable_container.js에 Entry.VariableContainer#removeRefs(objectId)를 추가했습니다. _variableRefs, _messageRefs, _functionRefs를 오브젝트 id 기준으로 필터링하고, default 뷰 모드가 아닐 때 목록을 갱신합니다.
2. src/class/container.js의 Entry.Container#removeObject()를 수정했습니다. object.destroy() 전에 removedObjectId를 캡처하고, removeLocalVariables(removedObjectId)에 이어 removeRefs(removedObjectId)를 isPass === true early return 앞에서 호출합니다. 장면 삭제가 removeObject(object, true)를 거치므로 이 호출 위치가 중요합니다.

범위:
- scene.js 변경 없음.
- 렌더/카운트 로직 변경 없음.
- object.destroy()/script.destroy() 동작 변경 없음.
- 의존성/포매팅 변경 없음.

test video: [YouTube](https://youtu.be/rZJZ86CWu0E)