### PR TITLE
[fix] 내용이 빈 글상자로 충돌·튕기기 블록 실행 시 오류 나는 문제 수정

### DIFF
--- a/src/playground/blocks/block_judgement.js
+++ b/src/playground/blocks/block_judgement.js
@@ -167,6 +167,11 @@ module.exports = {
                     const reg = /wall/;
                     const ath = 0.2;
                     const object = sprite.object;
+                    // 내용이 빈 글상자는 캔버스 렌더러에서 bounds가 null이라
+                    // 충돌을 판정할 수 없으므로 닿지 않은 것으로 처리한다.
+                    if (sprite.type === 'textBox' && !GEHelper.getTransformedBounds(object)) {
+                        return false;
+                    }
                     const isWall = reg.test(targetSpriteId);
                     const collision = ndgmr.checkPixelCollision;
                     if (isWall) {

--- a/src/playground/blocks/block_moving.js
+++ b/src/playground/blocks/block_moving.js
@@ -118,6 +118,7 @@ module.exports = {
                         sprite.type === 'textBox' &&
                         !GEHelper.getTransformedBounds(sprite.object)
                     ) {
+                        sprite.collision = Entry.Utils.COLLISION.NONE;
                         return script.callReturn();
                     }
                     const threshold = 0;

--- a/src/playground/blocks/block_moving.js
+++ b/src/playground/blocks/block_moving.js
@@ -1,3 +1,5 @@
+import { GEHelper } from '../../graphicEngine/GEHelper';
+
 module.exports = {
     getBlocks() {
         function moveInToBound(object, wall) {
@@ -110,6 +112,14 @@ module.exports = {
                 class: 'walk',
                 isNotFor: [],
                 func(sprite, script) {
+                    // 내용이 빈 글상자는 캔버스 렌더러에서 bounds가 null이라
+                    // 벽 충돌을 계산할 수 없으므로 튕기지 않고 넘어간다.
+                    if (
+                        sprite.type === 'textBox' &&
+                        !GEHelper.getTransformedBounds(sprite.object)
+                    ) {
+                        return script.callReturn();
+                    }
                     const threshold = 0;
                     const method = sprite.parent.getRotateMethod();
 

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -1345,6 +1345,10 @@ Entry.getKeyCodeMap = function () {
 };
 
 Entry.checkCollisionRect = function (rectA, rectB) {
+    // 내용이 빈 글상자처럼 bounds를 구할 수 없는(null) 대상은 충돌하지 않은 것으로 처리한다.
+    if (!rectA || !rectB) {
+        return false;
+    }
     return !(
         rectA.y + rectA.height < rectB.y ||
         rectA.y > rectB.y + rectB.height ||


### PR DESCRIPTION
## 작업 내용

<img width="643" height="352" alt="image" src="https://github.com/user-attachments/assets/7634fba2-afa5-4c47-ab05-31433a387aa6" />

내용이 비어 있는 글상자가 `~에 닿았는가?`(reach_something)나 `화면 끝에 닿으면 튕기기`(bounce_wall) 블록을 실행할 때, 부스트 모드가 꺼진(캔버스 렌더러) 상태에서 `TypeError`로 스크립트가 중단되던 문제를 수정합니다.

## 재현

1. 글상자 오브젝트를 추가합니다.
2. 다음과 같이 블록을 조립합니다.
   - `시작하기 버튼을 클릭했을 때`
   - `(  )(이)라고 글쓰기` — 내용을 빈 문자열로
   - `만일 <(엔트리봇)에 닿았는가?> (이)라면`
3. 부스트 모드를 끈 상태로 실행하면, 글쓰기로 글상자가 비는 순간 닿았는가? 판정에서 `Cannot read properties of null (reading 'y')` 오류가 발생하며 스크립트가 멈춥니다.

`~에 닿았는가?`의 벽 판정과 `화면 끝에 닿으면 튕기기`도 같은 원인으로 `reading 'x'` 오류가 발생합니다.

## 원인

캔버스(EaselJS) 렌더러에서 내용이 빈 글상자는 경계 사각형(bounds)이 `null`이 됩니다. `createjs.Text`는 텍스트가 빈 문자열이면 `getBounds()`가 `null`을 반환하고 배경 도형에도 bounds가 없어서 글상자 컨테이너 전체의 `getTransformedBounds()`가 `null`이 되기 때문입니다.

이 `null`이 아래 세 경로에서 가드 없이 그대로 사용됩니다.

- `reach_something`의 글상자 분기가 이 값을 `Entry.checkCollisionRect`에 넘겨 `rectA.y`를 참조하는 지점에서 오류가 납니다.
- `reach_something`의 벽 분기가 호출하는 `ndgmr.checkPixelCollision`이 `_collisionDistancePrecheck`에서 `ir1.x`를 참조하는 지점에서 오류가 납니다.
- `bounce_wall`도 같은 벽 충돌 경로를 사용하므로 동일하게 오류가 납니다.

WebGL(부스트 모드) 렌더러는 빈 글상자에도 최소 크기 텍스처를 만들어 bounds가 항상 존재하므로 이 오류가 발생하지 않습니다.

## 수정

넓이가 없어 bounds를 구할 수 없는 글상자는 아무것과도 닿지 않은 것으로 처리합니다. 같은 블록 함수 상단에서 보이지 않는 오브젝트를 처리하는 방식(`!sprite.getVisible()`이면 `false` 반환)과 같은 취지입니다.

- `reach_something` 함수 앞부분에서, 자신이 글상자이고 bounds가 없으면 `false`를 반환합니다.
- `Entry.checkCollisionRect`에 두 사각형 중 하나라도 없으면 `false`를 반환하는 가드를 추가합니다. 대상이 빈 글상자인 반대 방향과 복제본 판정까지 함께 처리됩니다.
- `bounce_wall` 함수 앞부분에서, 자신이 글상자이고 bounds가 없으면 튕기지 않고 넘어갑니다.

WebGL 렌더러는 bounds가 항상 존재하므로 이 가드가 동작하지 않아 기존 동작이 그대로 유지됩니다.

## 검증

- 수정 전 오류가 나던 네 경로(글상자→스프라이트, 스프라이트→글상자, 글상자→벽, 빈 글상자 튕기기)가 모두 오류 없이 처리됩니다.
- 내용이 있는 글상자의 충돌 판정은 그대로입니다(겹치면 참, 떨어지면 거짓).
- WebGL 렌더러에서 판정 결과가 수정 전과 동일합니다.