### PR TITLE
[fix] "브라우저로 연결하기" 실패 후 재선택 시 시리얼 포트 미해제 버그 수정

### DIFF
--- a/src/class/hardware/webSerialConnector.ts
+++ b/src/class/hardware/webSerialConnector.ts
@@ -167,7 +167,7 @@ export default class WebSerialConnector extends WebApiConnector {
 
     async constantServing() {
         try {
-            if (this.hwLite.getStatus() === 'disconnected') {
+            if (this.hwLite.getStatus() !== 'connected') {
                 return;
             }
             if (this.hwModule?.portData?.constantServing !== 'ReadOnly') {
@@ -181,7 +181,11 @@ export default class WebSerialConnector extends WebApiConnector {
 
             const { value, done } = await this.reader.read();
             if (done) {
-                this.hwLite.getConnectFailedMenu();
+                // read가 done으로 끝나는 경우는 두 가지다: 실제 연결 문제, 또는 포트 정리 과정의 reader 취소.
+                // 포트 정리는 정상 동작이므로, 연결 중이었을 때만 실패로 처리한다.
+                if (this.hwLite.getStatus() === 'connected') {
+                    this.hwLite.getConnectFailedMenu();
+                }
                 return;
             }
             this.hwModule?.handleLocalData(value);

--- a/src/class/hw_lite.ts
+++ b/src/class/hw_lite.ts
@@ -195,6 +195,9 @@ export default class HardwareLite {
             );
         } catch (error) {
             console.error(error);
+            // 연결에 실패해도 앞서 열어둔 포트는 열린 채 남는다. 여기서 닫아주지 않으면
+            // 같은 기기로 다시 연결할 때 open()이 "이미 열려 있음" 오류로 계속 실패한다.
+            await this.serial?.removeSerialPort().catch((err: Error) => console.error(err));
             Entry.toast.alert(
                 Lang.Msgs.hw_connection_failed_title,
                 Lang.Msgs.hw_connection_failed_desc,

--- a/src/class/hw_lite.ts
+++ b/src/class/hw_lite.ts
@@ -63,6 +63,11 @@ export default class HardwareLite {
     }
 
     setExternalModule(moduleObject: EntryHWLiteBaseModule) {
+        // 이전 연결의 포트를 닫지 않고 커넥터를 교체하면, 그 포트는 닫을 방법이 없어져
+        // 페이지 새로고침 전까지 재연결이 막힌다. 그래서 교체 전에 먼저 닫는다.
+        // 닫기 완료를 기다리지는 않는다(이 메서드는 동기 유지). 다음 연결은 어차피 사용자가
+        // 버튼을 누른 뒤에 시작되고, 작품 로드 경로에서는 연결된 적이 없어 이 줄은 그냥 지나간다.
+        this.serial?.removeSerialPort().catch((err: Error) => console.error(err));
         this.hwModule = moduleObject;
         this.banClassAllHardwareLite();
         Entry.block.changeBlockText('hardware_device_name_content', this.hwModule.title.ko);


### PR DESCRIPTION
Fixes #3081

## 변경 사항

"브라우저로 연결하기"에서 연결이 한 번 실패하면 그 뒤로 "연결하기"를 몇 번을 눌러도 계속 실패하고, 페이지를 새로고침해야만 복구되는 문제를 수정했습니다. (커밋 3개, 2파일, +13/−2)

| 커밋 | 내용 |
|---|---|
| 1 | 연결이 끝난 뒤에도 `constantServing` 루프가 계속 돌던 종료 조건 보강 |
| 2 | 연결 실패 시 열어둔 포트를 닫음. 실패해도 다음 재연결이 가능해짐 |
| 3 | 하드웨어 재선택 시 이전 커넥터의 포트를 닫음. 고아 포트 방지 |

새 API 없이 기존 public 메서드 `removeSerialPort()`와 기존 필드 `this.serial`만 사용했습니다. BLE 연결 경로는 건드리지 않습니다.

## 참고사항

원인은 다음과 같습니다.

- 연결이 실패했을 때 열어둔 시리얼 포트를 아무도 닫지 않습니다.
- 브라우저(Web Serial)는 같은 기기에 항상 같은 `SerialPort` 객체를 돌려주기 때문에, 포트가 열린 채 남아 있으면 다음 연결의 `open()`이 `InvalidStateError: The port is already open.` 으로 실패합니다.
- 연결 해제 없이 하드웨어를 다시 선택하면, 열린 포트를 들고 있던 커넥터가 새 커넥터로 교체되면서 그 포트를 닫을 방법 자체가 사라집니다.

특정 교구만의 문제가 아니라 Web Serial을 쓰는 하드웨어 라이트 모듈 30종 전체에 해당합니다. 무선 동글류처럼 핸드셰이크가 실패할 수 있는 교구에서, 교실에서 흔한 "실패하면 다시 연결 반복" 동선 그대로 재현됩니다.

수정 전 재현 방법:

1. 무선 동글이 다른 로봇과 페어링된 상태에서 연결 시도. 핸드셰이크 실패
2. 동글을 올바른 로봇과 다시 페어링하고 "연결하기" 재시도
3. 원래는 성공해야하지만 실제로는 `InvalidStateError: The port is already open.` 으로 실패하고, 이후 모든 재시도도 동일하게 실패합니다.

## 테스트 항목

실기 검증 환경: macOS + Chrome, 로보메이션 햄스터/거북이 + 공용 무선 동글

- 수정 전 위 재현 절차로 `InvalidStateError` 재현 확인
- 수정 후 같은 절차에서 재연결 정상 동작 확인
- 정상 연결 → 해제 → 재선택 → 재연결 정상 동작 확인
- 해제 없이 하드웨어 재선택 후 연결 정상 동작 확인
- 포트 선택창에서 취소 시 오류 없이 실패 처리되는지 확인
- `npm run dist` 빌드 통과(타입 에러 0), 수정 파일 eslint 통과 확인

