### PR TITLE
[fix] 함수 내부 런타임 에러 블록의 하이라이트가 사라지는 문제 수정

### DIFF
--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -2168,14 +2168,37 @@ Entry.Utils.stopProjectWithToast = _throttle(
             if (scope.block && 'funcBlock' in scope.block) {
                 block = scope.block.funcBlock;
             } else if (scope.funcExecutor) {
-                block = scope.funcExecutor.scope.block;
-                Entry.Func.edit(scope.type);
+                const errorBlock = scope.funcExecutor.scope.block;
+                const errorBlockId = errorBlock && errorBlock.id;
+                const funcId = (/(func_)?(.*)/.exec(scope.type) || [])[2];
+
+                // 한 번 실행에서 서로 다른 블록의 런타임 에러가 여러 번 올라올 수 있다.
+                // 그때마다 Entry.Func.edit 을 다시 호출하면 cancelEdit → initEditView 로
+                // 함수 보드가 재렌더되어 앞서 붙인 하이라이트가 지워진다. 마지막 호출이
+                // 하이라이트를 복구하지 못하면 경고만 남고 테두리는 사라진다.
+                // 이미 같은 함수를 편집 중이면 다시 열지 않는다.
+                const isEditingSameFunc =
+                    Entry.Func.isEdit &&
+                    Entry.Func.targetFunc &&
+                    Entry.Func.targetFunc.id === funcId;
+
+                if (!isEditingSameFunc) {
+                    Entry.Func.edit(scope.type);
+                }
+
+                // edit 가 실행된 경우 Block 인스턴스가 교체될 수 있으므로 id 로 다시 찾는다.
+                const func = funcId && Entry.variableContainer.getFunction(funcId);
+                const reloadedBlock =
+                    errorBlockId && func && func.content && func.content.findById(errorBlockId);
+
+                block = reloadedBlock || errorBlock;
             }
 
             if (block) {
-                const id = block.getCode().object && block.getCode().object.id;
+                const code = block.getCode();
+                const id = code && code.object && code.object.id;
                 if (id) {
-                    Entry.container.selectObject(block.getCode().object.id, true);
+                    Entry.container.selectObject(id, true);
                 }
                 const view = block.view;
                 view && view.getBoard().activateBlock(block);

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -2160,6 +2160,9 @@ Entry.Utils.stopProjectWithToast = _throttle(
         message = message || 'Runtime Error';
         const toast = error.toast;
         const engine = Entry.engine;
+        const funcExecutor = scope.funcExecutor;
+        const funcErrorBlock = funcExecutor && funcExecutor.scope.block;
+        const funcErrorBlockId = funcErrorBlock && funcErrorBlock.id;
 
         if (engine && engine.isState('run')) {
             await engine.toggleStop();
@@ -2167,9 +2170,9 @@ Entry.Utils.stopProjectWithToast = _throttle(
         if (Entry.type === 'workspace') {
             if (scope.block && 'funcBlock' in scope.block) {
                 block = scope.block.funcBlock;
-            } else if (scope.funcExecutor) {
-                const errorBlock = scope.funcExecutor.scope.block;
-                const errorBlockId = errorBlock && errorBlock.id;
+            } else if (funcExecutor) {
+                const errorBlock = funcErrorBlock;
+                const errorBlockId = funcErrorBlockId;
                 const funcId = (/(func_)?(.*)/.exec(scope.type) || [])[2];
 
                 // 한 번 실행에서 서로 다른 블록의 런타임 에러가 여러 번 올라올 수 있다.


### PR DESCRIPTION
# 함수 내부 런타임 에러 블록의 하이라이트가 사라지는 문제 수정

## 🐛 문제 상황

함수(function) 안에서 런타임 에러가 발생하면 `빨간색으로 표시된 블록을 확인해 주세요.` 경고 토스트는 표시되지만, **정작 에러가 발생한 블록에 빨간 테두리가 표시되지 않습니다.** 사용자는 안내를 받고도 원인 블록을 찾을 수 없습니다.

함수 편집창을 미리 열어둔 상태에서 실행해도 동일하게 재현됩니다.

**원인**

`Entry.Utils.stopProjectWithToast`는 함수 내부 에러일 때 `Entry.Func.edit()`으로 함수 편집창을 열고, 그 다음 `board.activateBlock(block)`으로 하이라이트를 적용합니다.

그런데 한 번의 실행에서 **서로 다른 블록의 런타임 에러가 여러 번 보고될 수 있습니다.** 호출부가 `stopProjectWithToast`를 await하지 않고, 이 함수는 내부에서 `await engine.toggleStop()`을 하므로 첫 await 시점에 즉시 반환됩니다. 엔진이 실제로 멈추기 전까지 다른 tick이 계속 실행되어 추가 에러가 발생합니다.

계측 결과 호출 순서는 다음과 같았습니다.

```
[Func.edit]      → [activateBlock] (테두리 적용)
[Func.edit]      → 보드 재렌더로 테두리 소실 → [activateBlock] (다시 적용)
[Func.edit]      → 보드 재렌더로 테두리 소실 → activateBlock 호출되지 않음
```

`Entry.Func.edit()`은 내부에서 `cancelEdit()` → `initEditView()`를 수행하며 함수 보드를 재렌더합니다. 이 과정에서 앞서 적용된 `activated` 클래스가 사라집니다. 마지막 보고가 하이라이트를 복구하지 못하면 **경고만 남고 테두리는 없는 상태로 끝납니다.**

또한 `cancelEdit()`이 `content.load()`로 함수 코드를 재적재하는 경우 기존 `Block` 인스턴스가 교체되어, 미리 캡처해둔 블록 참조가 `view`를 잃을 수 있습니다.

## ✅ 해결 방안

### 1. 이미 같은 함수를 편집 중이면 `Entry.Func.edit()`을 다시 호출하지 않음

```js
const isEditingSameFunc =
    Entry.Func.isEdit && Entry.Func.targetFunc && Entry.Func.targetFunc.id === funcId;

if (!isEditingSameFunc) {
    Entry.Func.edit(scope.type);
}
```

불필요한 보드 재렌더가 사라져 적용된 하이라이트가 유지됩니다. 이미 열려 있는 편집창을 매번 닫고 다시 여는 낭비도 제거됩니다.

### 2. 블록 참조 대신 id로 재조회

`Entry.Func.edit()`이 실제로 실행된 경우에는 `Block` 인스턴스가 교체될 수 있으므로, id를 남겨두고 편집창을 연 뒤 `content.findById()`로 다시 찾습니다. 찾지 못하면 기존 참조로 폴백합니다.

### 3. `block.getCode()` 방어 코드 추가

함수 정의 블록은 `getCode().object`가 없을 수 있어 기존 코드가 예외를 던질 여지가 있었습니다.

## 🎯 예상 영향 범위

| 상황 | 변경 전 | 변경 후 |
|---|---|---|
| 함수 내부 에러 1건 | 테두리 표시됨 | 동일 |
| 함수 내부 에러 여러 건 | **테두리 사라짐** | 테두리 유지 |
| 같은 함수 편집 중 재보고 | 편집창 재렌더 | 재렌더 없음 |
| 함수 밖 에러 | 영향 없음 | 영향 없음 |

- 하이라이트 대상 결정과 함수 편집창 열기 로직만 변경했습니다. 토스트·엔진 정지 동작은 그대로입니다.
- `'funcBlock' in scope.block` 분기는 손대지 않았습니다.
- 사용자 입장에서는 경고 문구가 가리키는 빨간 테두리가 실제로 보이게 됩니다.

## 🧪 검증

함수 7개(일반 함수 6, 값 함수 1)를 사용하고 리스트 인덱스 범위를 벗어나는 작품으로 재현·검증했습니다.

- 변경 전: 경고 토스트만 표시, 테두리 없음
- 변경 후: 에러가 발생한 블록에 빨간 테두리 표시 확인

## 📝 남은 과제

동일한 실행에서 에러가 여러 번 보고되면 **경고 토스트도 중복 표시**됩니다. `stopProjectWithToast`가 `_throttle`로 300ms만 묶여 있고, 마지막 `throw`가 async 함수 안에 있어 실행기를 동기적으로 중단하지 못하는 구조적 원인입니다.

이번 PR은 리포트된 증상(하이라이트 미표시) 해결에 집중했고, 토스트 중복은 영향 범위가 달라 별도로 다루는 것이 안전하다고 판단했습니다.
