### PR TITLE
fix: 지수 표기(1e+21)를 숫자로 인정하도록 isNumber 정규식 확장

### DIFF
--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -464,11 +464,14 @@ Entry.overridePrototype = function () {
 // INFO: 기존에 사용하던 isNaN에는 숫자 체크의 문자가 있을수 있기때문에 regex로 체크하는 로직으로 변경
 // isNaN 문제는 https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/isNaN
 // 에서 확인.
+// INFO: 지수 표기(1e+21)도 숫자로 인정한다. JS 는 |x| >= 1e21 부터 String(x) 와
+// Number.prototype.toFixed() 가 지수 표기를 반환하므로, 엔트리가 스스로 만들어낸
+// 값이 다시 입력으로 들어왔을 때 숫자로 판정되지 않던 문제가 있었다.
 Entry.Utils.isNumber = function (num) {
     if (typeof num === 'number') {
         return true;
     }
-    const reg = /^-?\d+\.?\d*$/;
+    const reg = /^-?\d+\.?\d*(?:[eE][+-]?\d+)?$/;
     if (typeof num === 'string' && reg.test(num)) {
         return true;
     }

--- a/test/playground/blocks/calc_basic.spec.js
+++ b/test/playground/blocks/calc_basic.spec.js
@@ -1,0 +1,98 @@
+/**
+ * 회귀 테스트 — calc_basic(계산: ○ + ○) 의 지수 표기 처리
+ *
+ * VOC: 변수 값이 1e+21 형태가 된 뒤 더하기가 문자열 결합으로 처리됨.
+ *      예) 1e+21 + 1e+21 → "1e+211e+21"
+ *
+ * PLUS 분기만 Entry.Utils.isNumber 로 피연산자를 재판정하고, 숫자가 아니라고
+ * 판정되면 getNumberValue 가 parseFloat 로 이미 파싱한 값을 문자열로 되돌린다.
+ * MINUS/MULTI/DIVIDE 는 getNumberValue 만 쓰므로 원래부터 영향이 없다.
+ */
+
+// 실제 실행 환경에서는 index.html 의 script 태그가 이 전역들을 채운다.
+global.Entry = {};
+global._ = require('lodash');
+global.BigNumber = require('../../../extern/util/bignumber.min.js');
+
+// EntryStatic 과 Lang 은 블록의 색상·표시 문구에만 쓰인다.
+// 어떤 속성을 읽어도 자기 자신을 돌려주는 스텁으로 충분하다.
+const anyValue = new Proxy(function stub() {}, {
+    get: (target, key) => (key === Symbol.toPrimitive ? () => 'stub' : anyValue),
+    apply: () => anyValue,
+});
+global.EntryStatic = anyValue;
+global.Lang = anyValue;
+
+jest.mock('../../../src/graphicEngine/GEHelper', () => ({ GEHelper: {} }));
+jest.mock('../../../src/class/DataTable', () => ({}));
+jest.mock('../../../src/class/entryModuleLoader', () => ({}));
+jest.mock('fontfaceonload', () => () => {});
+
+require('../../../src/util/utils');
+
+// 블록 정의가 참조하는 파라미터 컨버터. 실제로는 block_entry.js 가 채운다.
+Entry.block = { converters: anyValue };
+
+const calcBasic = require('../../../src/playground/blocks/block_calc').getBlocks().calc_basic;
+
+/**
+ * Entry.Scope 를 대신하는 최소 스텁.
+ * getNumberValue 의 계산식은 src/playground/scope.js:139 와 동일하게 맞춘다.
+ */
+function run(left, operator, right) {
+    const params = { LEFTHAND: left, RIGHTHAND: right };
+    const script = {
+        getField: () => operator,
+        getValue: (key) => params[key],
+        getNumberValue: (key) => parseFloat(params[key]) || 0,
+    };
+    return calcBasic.func(null, script);
+}
+
+describe('calc_basic — 더하기(PLUS)', () => {
+    test('지수 표기끼리 더하면 숫자 덧셈이 된다', () => {
+        expect(run('1e+21', 'PLUS', '1e+21')).toBe(2e21);
+    });
+
+    test('결과가 문자열이 아니라 number 다', () => {
+        expect(typeof run('1e+21', 'PLUS', '1e+21')).toBe('number');
+    });
+
+    test('한쪽만 지수 표기여도 더해진다', () => {
+        expect(run('2e3', 'PLUS', '1')).toBe(2001);
+    });
+
+    test('변수에 저장된 지수 문자열을 그대로 다시 계산할 수 있다', () => {
+        // `변수에 ○만큼 더하기`(block_variable.js:451)는 .toNumber().toFixed() 를 거치는데,
+        // JS 는 |x| >= 1e21 에서 지수 표기를 반환한다. 그 값이 다음 연산의 입력이 된다.
+        const stored = (1e21).toFixed(0);
+        expect(stored).toBe('1e+21');
+        expect(run(stored, 'PLUS', stored)).toBe(2e21);
+    });
+
+    test('글자끼리는 그대로 이어 붙인다', () => {
+        expect(run('안녕', 'PLUS', '하세요')).toBe('안녕하세요');
+    });
+
+    test('숫자와 글자를 더하면 이어 붙인다', () => {
+        expect(run('1', 'PLUS', '개')).toBe('1개');
+    });
+
+    test('소수점 오차가 생기지 않는다', () => {
+        expect(run('0.1', 'PLUS', '0.2')).toBe(0.3);
+    });
+});
+
+describe('calc_basic — 나머지 연산자는 원래부터 지수 표기를 처리한다', () => {
+    test('빼기', () => {
+        expect(run('2e+21', 'MINUS', '1e+21')).toBe(1e21);
+    });
+
+    test('곱하기', () => {
+        expect(run('2e3', 'MULTI', '3')).toBe(6000);
+    });
+
+    test('나누기', () => {
+        expect(run('2e3', 'DIVIDE', '4')).toBe(500);
+    });
+});

--- a/test/util/isNumber.spec.js
+++ b/test/util/isNumber.spec.js
@@ -1,0 +1,103 @@
+/**
+ * 회귀 테스트 — 지수 표기(1e+21) 숫자 판정
+ *
+ * VOC: 변수 값이 1e+21 형태로 바뀐 뒤 더하기 연산이 문자열 결합으로 처리됨.
+ *      예) 1e+21 + 1e+21 → "1e+211e+21"
+ *
+ * 원인: 자바스크립트는 |x| >= 1e21 부터 String(x) 와 Number.prototype.toFixed()
+ *      가 지수 표기를 반환한다. 그렇게 만들어진 "1e+21" 을 Entry.Utils.isNumber
+ *      의 정규식이 숫자로 인정하지 않아, parseFloat 로 이미 파싱된 값을
+ *      block_calc.js 의 PLUS 분기가 다시 문자열로 되돌린다.
+ */
+
+// utils.js 는 모듈 로드 시점에 전역 Entry 와 lodash 전역 `_` 를 사용한다.
+// 실제 실행 환경에서는 index.html 의 script 태그가 이 전역들을 채운다.
+global.Entry = {};
+global._ = require('lodash');
+
+// isNumber / parseNumber 검증에 관여하지 않는 무거운 의존성은 대체한다.
+jest.mock('../../src/graphicEngine/GEHelper', () => ({ GEHelper: {} }));
+jest.mock('../../src/class/DataTable', () => ({}));
+jest.mock('../../src/class/entryModuleLoader', () => ({}));
+jest.mock('fontfaceonload', () => () => {});
+
+require('../../src/util/utils');
+
+describe('Entry.Utils.isNumber', () => {
+    describe('지수 표기를 숫자로 인정한다', () => {
+        test.each(['1e+21', '1e21', '-1e+21', '2E3', '-1.5E-7', '1.5e+21', '1e-7'])(
+            '%s',
+            (value) => {
+                expect(Entry.Utils.isNumber(value)).toBe(true);
+            }
+        );
+    });
+
+    describe('숫자가 아닌 문자열은 계속 거부한다', () => {
+        test.each([
+            'e',
+            'E',
+            'e21',
+            'E4',
+            '1e',
+            '1e+',
+            '1e5.5',
+            '0x10',
+            ' 12',
+            '12 ',
+            'Infinity',
+            'NaN',
+            '.5',
+            '.',
+            '-',
+            '',
+            '1--2',
+            '도',
+        ])('%s', (value) => {
+            expect(Entry.Utils.isNumber(value)).toBe(false);
+        });
+    });
+
+    describe('기존에 통과하던 값은 그대로 통과한다 (단조 확장)', () => {
+        test.each(['0', '1', '-1', '12.', '12.5', '000123', '-0.001'])('%s', (value) => {
+            expect(Entry.Utils.isNumber(value)).toBe(true);
+        });
+    });
+
+    describe('number 타입은 언제나 통과한다', () => {
+        test.each([0, 1, -1.5, 1e21, Number.MAX_SAFE_INTEGER])('%p', (value) => {
+            expect(Entry.Utils.isNumber(value)).toBe(true);
+        });
+    });
+
+    describe('한 글자 입력 필터 동작이 바뀌지 않는다', () => {
+        // FieldTextInput._isValidInputValue (src/playground/field/textInput.js:458) 과
+        // FieldAngle._isValidInputValue (src/playground/field/angle.js:255) 는
+        // 방금 입력된 키 "한 글자" 를 그대로 넘긴다. 여기서 'e' 가 통과되면
+        // 숫자 입력칸에 e 를 타이핑할 수 있게 되어 기존 동작이 깨진다.
+        test.each(['e', 'E', '+', 'x', 'a'])('%s 는 여전히 거부한다', (ch) => {
+            expect(Entry.Utils.isNumber(ch)).toBe(false);
+        });
+
+        test.each(['0', '5', '9'])('%s 는 여전히 통과한다', (ch) => {
+            expect(Entry.Utils.isNumber(ch)).toBe(true);
+        });
+    });
+});
+
+describe('Entry.parseNumber', () => {
+    // Entry.Variable 생성자(src/class/variable/variable.js:63)가 저장된 프로젝트의
+    // 값을 이 함수로 복원한다. false 를 반환하면 변수 값이 문자열로 고정되어
+    // 이후 연산이 전부 문자열 결합이 된다.
+    test('지수 표기 문자열을 숫자로 복원한다', () => {
+        expect(Entry.parseNumber('1e+21')).toBe(1e21);
+    });
+
+    test('0 으로 시작하는 값은 기존대로 문자열을 유지한다', () => {
+        expect(Entry.parseNumber('0123')).toBe('0123');
+    });
+
+    test('숫자가 아니면 false 를 반환한다', () => {
+        expect(Entry.parseNumber('안녕')).toBe(false);
+    });
+});


### PR DESCRIPTION
변수 값이 1e+21 형태가 된 뒤 더하기 연산이 숫자 덧셈이 아닌 문자열
결합으로 처리되는 문제를 수정한다.

원인
- JS 는 |x| >= 1e21 부터 String(x) 와 Number.prototype.toFixed() 가 지수 표기를 반환한다. `변수에 O만큼 더하기`(block_variable.js)의 .toNumber().toFixed() 가 이 경계에서 "1e+21" 문자열을 만들어 변수에 저장한다.
- Entry.Utils.isNumber 의 정규식이 지수 표기를 매치하지 않아, calc_basic 의 PLUS 분기가 parseFloat 로 이미 파싱된 값을 다시 문자열로 되돌린다. 같은 함수 안에서 parseFloat 와 isNumber 의 판정이 어긋나 있던 것이 문제의 실체다.

수정 범위
- utils.js 의 정규식 한 줄만 확장한다. false -> true 로 바뀌는 값은 지수 표기 문자열뿐이고 기존에 true 였던 값이 false 가 되는 경우는 없다(단조 확장). 한 글자 단위로 검사하는 입력 필터(textInput/angle) 에서도 'e' 단독은 여전히 매치되지 않아 동작이 변하지 않는다.
- block_calc.js 와 block_variable.js 는 변경하지 않는다. block_variable 의 .toNumber() 를 제거하면 `변수에 더하기`와 `변수 정하기`의 표시가 갈리므로 표시 정책은 별도 과제로 분리한다.

동작 변경(QA 확인 필요)
- `O이(가) 숫자인가?` 블록이 1e+21 에 참을 반환한다.
- 지수 문자열을 담은 변수가 숫자 변수로 취급된다.
- 파이썬 변환 시 지수 표기가 따옴표 없이 출력된다.

테스트
- test/util/isNumber.spec.js (48) 지수 표기 인정, 거부 대상 유지, 단조 확장, 한 글자 입력 필터 가드, parseNumber 프로젝트 로드 경로
- test/playground/blocks/calc_basic.spec.js (10) VOC 재현, toFixed 산출값 재계산, 글자 결합/소수점 오차/나머지 연산자 가드