### PR TITLE
[fix] 함수 지역변수 id를 생성 시점에 발급

### DIFF
--- a/src/class/function.js
+++ b/src/class/function.js
@@ -16,7 +16,11 @@ class EntryFunc {
         } = func;
         this.id = id;
         this.type = type;
-        this.localVariables = localVariables;
+        this.localVariables = localVariables.map((localVariable) =>
+            localVariable.id
+                ? localVariable
+                : { ...localVariable, id: `${id}_${Entry.generateHash()}` }
+        );
         this.useLocalVariables = useLocalVariables;
         let content;
         //inspect empty content
@@ -86,6 +90,7 @@ class EntryFunc {
 
     defaultLocalVariable(isForce) {
         return {
+            id: `${this.id}_${Entry.generateHash()}`,
             name: this.makeLocalVariableName(isForce),
             value: 0,
         };

--- a/src/playground/blocks/block_func.js
+++ b/src/playground/blocks/block_func.js
@@ -97,13 +97,7 @@ module.exports = {
                                 {};
                             const localVariables = func.localVariables || [];
                             if (localVariables.length) {
-                                return localVariables.map((localVariable) => {
-                                    const { id, name } = localVariable;
-                                    if (!id) {
-                                        localVariable.id = `${func.id}_${Entry.generateHash()}`;
-                                    }
-                                    return [name, localVariable.id];
-                                });
+                                return localVariables.map(({ id, name }) => [name, id]);
                             } else {
                                 return [[Lang.Blocks.no_target, 'null']];
                             }
@@ -210,13 +204,7 @@ module.exports = {
                                 {};
                             const localVariables = func.localVariables || [];
                             if (localVariables.length) {
-                                return localVariables.map((localVariable) => {
-                                    const { id, name } = localVariable;
-                                    if (!id) {
-                                        localVariable.id = `${func.id}_${Entry.generateHash()}`;
-                                    }
-                                    return [name, localVariable.id];
-                                });
+                                return localVariables.map(({ id, name }) => [name, id]);
                             } else {
                                 return [[Lang.Blocks.no_target, 'null']];
                             }


### PR DESCRIPTION
함수 지역변수의 id가 생성 시점이 아니라 지역변수 블록의 드롭다운이 렌더링될 때(`block_func`의 `menuName`) 발급되고 있습니다.

이 때문에 두 가지 문제가 있습니다.

- 변수·리스트·신호·테이블·함수 등 다른 요소는 모두 생성 시점에 id를 발급하는 것과 비일관적입니다.
- 지역변수 블록이 렌더링되기 전에 프로젝트가 저장되면 `functions[].localVariables`에 id 없는 항목이 저장됩니다. 같은 프로젝트라도 편집 경로에 따라 저장 결과가 달라지고, id가 있다고 가정하는 코드에서 오동작의 원인이 될 수 있습니다. 실제로 id 없이 저장된 프로젝트를 확인했습니다.

```json
"localVariables": [
    { "name": "인사말", "value": 0 }
]
```

다음과 같이 변경합니다.

- `defaultLocalVariable`에서 기존과 같은 형식(`${func.id}_${generateHash()}`)으로 id를 생성 시점에 발급합니다.
- 기존에 id 없이 저장된 프로젝트는 `Function` 생성자에서 로드 시 보정합니다. `EntryObject` 생성자가 sounds/pictures 의 누락된 id를 보정하는 것과 같은 방식입니다.
- 위 두 가지로 id가 항상 보장되므로, 메뉴를 그리면서 모델을 수정하던 `menuName`의 지연 발급을 제거합니다.
