### PR TITLE
[fix] 함수 삭제 시 클립보드에 남은 함수 호출 블록 정리

### DIFF
--- a/src/class/variable_container.js
+++ b/src/class/variable_container.js
@@ -1442,7 +1442,35 @@ Entry.VariableContainer = class VariableContainer {
         for (const id in functions) {
             functions[id].content.removeBlocksByType(functionType);
         }
+        this.removeFuncBlocksFromClipboard(functionType);
         this.updateList();
+    }
+
+    /**
+     * 복사해 둔 블록이 붙여넣기로 되살아나 정의 없는 함수 호출이 생기지 않도록,
+     * 스크립트와 동일하게 클립보드에서도 해당 함수 호출 블록을 제거합니다.
+     * params 슬롯은 인자 위치가 유지되도록 제거 대신 빈 슬롯(null)으로 바꿉니다.
+     * @param {string} functionType
+     */
+    removeFuncBlocksFromClipboard(functionType) {
+        if (!Array.isArray(Entry.clipboard)) {
+            return;
+        }
+
+        const isFuncBlock = (value) =>
+            value && typeof value === 'object' && value.type === functionType;
+        const removeFromBlock = (block) => ({
+            ...block,
+            params: (block.params || []).map((param) =>
+                isFuncBlock(param) ? null : param && param.type ? removeFromBlock(param) : param
+            ),
+            statements: (block.statements || []).map(removeFromThread),
+        });
+        const removeFromThread = (thread) =>
+            thread.filter((block) => !isFuncBlock(block)).map(removeFromBlock);
+
+        const cleaned = removeFromThread(Entry.clipboard);
+        Entry.clipboard = cleaned.length ? cleaned : null;
     }
 
     removeNotPythonSupportedFunction() {
@@ -1458,6 +1486,7 @@ Entry.VariableContainer = class VariableContainer {
                 for (const id in functions) {
                     functions[id].content.removeBlocksByType(functionType);
                 }
+                this.removeFuncBlocksFromClipboard(functionType);
             }
         });
         this.updateList();


### PR DESCRIPTION
문제

함수를 삭제하면 오브젝트 스크립트와 다른 함수 본문의 호출 블록은 함께 정리되지만, 코드 복사로 만들어진 클립보드 스냅샷은 정리되지 않습니다. 이 상태에서 붙여넣기를 하면 정의가 없는 함수 호출 블록이 
프로젝트에 되살아납니다.

수정 내용

함수 삭제 시(파이썬 모드 전환의 미지원 함수 일괄 삭제 포함) 클립보드 스냅샷에도 스크립트와 동일한 정리를 적용합니다.

- 스레드에서는 해당 함수 호출 블록을 제거
- params 슬롯은 인자 위치가 유지되도록 제거 대신 빈 슬롯(null)으로 치환
- statements는 재귀적으로 정리
- 정리 결과가 비면 클립보드를 기본값(null)으로 되돌려 붙여넣기를 비활성화

검증

- 로컬 dev 서버(example 워크스페이스)에서 위 재현 절차 수행 시 고아 호출 블록이 더 이상 생기지 않음을 확인
- 정리 로직을 스레드 최상위·param 슬롯·statements 내부 3개 위치에 대해 검증 (제거/치환/재귀 각각 의도대로 동작)